### PR TITLE
Fix: number of frames saved to HDF5

### DIFF
--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -239,16 +239,16 @@ class HDF5RecordController:
 
                 elif isinstance(data, FrameData):
                     captured_frames += data.data.shape[0]
-                    
+
                     num_frames_to_capture: int = self._num_capture_record.get()
                     if (
-                        num_frames_to_capture > 0 
+                        num_frames_to_capture > 0
                         and captured_frames > num_frames_to_capture
                     ):
                         # Discard extra collected data points if necessary
-                        data.data = data.data[:num_frames_to_capture - captured_frames]
+                        data.data = data.data[: num_frames_to_capture - captured_frames]
                         captured_frames = num_frames_to_capture
-                    
+
                     pipeline[0].queue.put_nowait(data)
 
                     if (

--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -238,9 +238,19 @@ class HDF5RecordController:
                         pipeline[0].queue.put_nowait(data)
 
                 elif isinstance(data, FrameData):
-                    pipeline[0].queue.put_nowait(data)
-                    captured_frames += 1
+                    captured_frames += data.data.shape[0]
+                    
                     num_frames_to_capture: int = self._num_capture_record.get()
+                    if (
+                        num_frames_to_capture > 0 
+                        and captured_frames > num_frames_to_capture
+                    ):
+                        # Discard extra collected data points if necessary
+                        data.data = data.data[:num_frames_to_capture - captured_frames]
+                        captured_frames = num_frames_to_capture
+                    
+                    pipeline[0].queue.put_nowait(data)
+
                     if (
                         num_frames_to_capture > 0
                         and captured_frames >= num_frames_to_capture

--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -238,7 +238,7 @@ class HDF5RecordController:
                         pipeline[0].queue.put_nowait(data)
 
                 elif isinstance(data, FrameData):
-                    captured_frames += data.data.shape[0]
+                    captured_frames += len(data.data)
 
                     num_frames_to_capture: int = self._num_capture_record.get()
                     if (

--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -156,6 +156,9 @@ class Rows:
     def __init__(self, *rows):
         self.rows = rows
 
+    def __len__(self):
+        return len(self.rows)
+
     def __eq__(self, o):
         same = o.tolist() == [pytest.approx(row) for row in self.rows]
         return same

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 import h5py
 import numpy
+import pytest
 import pytest_asyncio
 from aioca import caget, camonitor, caput
 from fixtures.mocked_panda import (
@@ -348,10 +349,9 @@ async def test_hdf5_ioc_parameter_validate_works(hdf5_subprocess_ioc_no_logging_
     assert val.tobytes().decode() == "/new/path"  # put should have been stopped
 
 
+@pytest.mark.parametrize("num_capture", [1, 1000, 10000])
 async def test_hdf5_file_writing(
-    hdf5_subprocess_ioc,
-    tmp_path: Path,
-    caplog,
+    hdf5_subprocess_ioc, tmp_path: Path, caplog, num_capture
 ):
     """Test that an HDF5 file is written when Capture is enabled"""
     test_dir = str(tmp_path) + "\0"
@@ -376,8 +376,6 @@ async def test_hdf5_file_writing(
     val = await caget(HDF5_PREFIX + ":FileName")
     assert val.tobytes().decode() == test_filename
 
-    # The example data contains 10000 data points, but we acquire only 1000
-    num_capture = 1000
     assert await caget(HDF5_PREFIX + ":NumCapture") == 0
     await caput(HDF5_PREFIX + ":NumCapture", num_capture, wait=True, timeout=TIMEOUT)
     assert await caget(HDF5_PREFIX + ":NumCapture") == num_capture

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -376,10 +376,11 @@ async def test_hdf5_file_writing(
     val = await caget(HDF5_PREFIX + ":FileName")
     assert val.tobytes().decode() == test_filename
 
-    # Only a single FrameData in the example data
+    # The example data contains 10000 data points, but we acquire only 1000
+    num_capture = 1000
     assert await caget(HDF5_PREFIX + ":NumCapture") == 0
-    await caput(HDF5_PREFIX + ":NumCapture", 1, wait=True, timeout=TIMEOUT)
-    assert await caget(HDF5_PREFIX + ":NumCapture") == 1
+    await caput(HDF5_PREFIX + ":NumCapture", num_capture, wait=True, timeout=TIMEOUT)
+    assert await caget(HDF5_PREFIX + ":NumCapture") == num_capture
 
     # The queue expects to see Capturing go 0 -> 1 -> 0 as Capture is enabled
     # and subsequently finishes
@@ -418,7 +419,7 @@ async def test_hdf5_file_writing(
         "PCAP.TS_START.Value",
     ]
 
-    assert len(hdf_file["/COUNTER1.OUT.Max"]) == 10000
+    assert len(hdf_file["/COUNTER1.OUT.Max"]) == num_capture
 
 
 def test_hdf_parameter_validate_not_capturing(hdf5_controller: HDF5RecordController):


### PR DESCRIPTION
Fixed the code that stops data capture once the preset maximum number of frames is collected. The HDF5 file will not contain more data points then the maximum number of frames. If the maximum number of frames is 0, then data capture continues until it is stopped.

The code was tested manually using PandABox. `PCAP` module was triggered by pulses from `CLOCK` and the number of samples (frames) to capture was set using `HDF5.NumCapture`.