### PR TITLE
Fix dist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ COPY --from=build /venv/ /venv/
 ENV PATH=/venv/bin:$PATH
 
 # change this entrypoint if it is not the same as the repo
-ENTRYPOINT ["PandABlocks-ioc"]
+ENTRYPOINT ["pandablocks-ioc"]
 CMD ["--version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=64", "setuptools_scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "PandABlocks-ioc"
+name = "pandablocks-ioc"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",
@@ -47,7 +47,7 @@ dev = [
 ]
 
 [project.scripts]
-PandABlocks-ioc = "pandablocks_ioc.__main__:cli"
+pandablocks-ioc = "pandablocks_ioc.__main__:cli"
 
 [project.urls]
 GitHub = "https://github.com/PandABlocks/PandABlocks-ioc"


### PR DESCRIPTION
Closes #33 

The dist fails because of the name in the pyproject.toml:

```
/opt/hostedtoolcache/Python/3.11.4/x64/bin/python: Error while finding module specification for 'PandABlocks_ioc.egg-info' (ModuleNotFoundError: No module named 'PandABlocks_ioc')
```
`PandABlocks-ioc` is formatted to `PandABlocks_ioc`.
