### PR TITLE
Added new command line arguments

### DIFF
--- a/src/pandablocks_ioc/__main__.py
+++ b/src/pandablocks_ioc/__main__.py
@@ -32,14 +32,29 @@ def cli(ctx, log_level: str):
 @cli.command()
 @click.argument("host")
 @click.argument("prefix")
-@click.argument("screens_dir")
-def softioc(host: str, prefix: str, screens_dir: str):
+@click.option(
+    "--screens-dir",
+    type=str,
+    help=(
+        "Provide an existing directory to export generated bobfiles to, if no "
+        "directory is provided then bobfiles will not be generated."
+    ),
+)
+@click.option("--skip-bobfile-gen-if-dir-not-empty", default=False, is_flag=True)
+def softioc(
+    host: str,
+    prefix: str,
+    screens_dir: str,
+    skip_bobfile_gen_if_dir_not_empty: bool,
+):
     """
     Connect to the given HOST and create an IOC with the given PREFIX.
-    Create .bob files for screens in the SCREENS_DIR. Directory must exist.
     """
     create_softioc(
-        client=AsyncioClient(host), record_prefix=prefix, screens_dir=screens_dir
+        client=AsyncioClient(host),
+        record_prefix=prefix,
+        screens_dir=screens_dir,
+        skip_bobfile_gen_if_dir_not_empty=skip_bobfile_gen_if_dir_not_empty,
     )
 
 

--- a/src/pandablocks_ioc/__main__.py
+++ b/src/pandablocks_ioc/__main__.py
@@ -40,21 +40,30 @@ def cli(ctx, log_level: str):
         "directory is provided then bobfiles will not be generated."
     ),
 )
-@click.option("--skip-bobfile-gen-if-dir-not-empty", default=False, is_flag=True)
+@click.option(
+    "--clear-bobfiles",
+    default=False,
+    is_flag=True,
+    help="Clear bobfiles from the given `--screens-dir` before generating new ones.",
+)
 def softioc(
     host: str,
     prefix: str,
     screens_dir: str,
-    skip_bobfile_gen_if_dir_not_empty: bool,
+    clear_bobfiles: bool,
 ):
     """
     Connect to the given HOST and create an IOC with the given PREFIX.
     """
+
+    if clear_bobfiles and not screens_dir:
+        raise RuntimeError("--clear-bobfiles passed in without a --screens-dir")
+
     create_softioc(
         client=AsyncioClient(host),
         record_prefix=prefix,
         screens_dir=screens_dir,
-        skip_bobfile_gen_if_dir_not_empty=skip_bobfile_gen_if_dir_not_empty,
+        clear_bobfiles=clear_bobfiles,
     )
 
 

--- a/src/pandablocks_ioc/__main__.py
+++ b/src/pandablocks_ioc/__main__.py
@@ -57,7 +57,7 @@ def softioc(
     """
 
     if clear_bobfiles and not screens_dir:
-        raise RuntimeError("--clear-bobfiles passed in without a --screens-dir")
+        raise ValueError("--clear-bobfiles passed in without a --screens-dir")
 
     create_softioc(
         client=AsyncioClient(host),

--- a/src/pandablocks_ioc/_pvi.py
+++ b/src/pandablocks_ioc/_pvi.py
@@ -154,7 +154,7 @@ class Pvi:
     pvi_info_dict: Dict[str, Dict[PviGroup, List[Component]]] = {}
 
     @staticmethod
-    def set_screens_dir(screens_dir: Optional[str], clear_bobfiles: bool):
+    def configure_pvi(screens_dir: Optional[str], clear_bobfiles: bool):
         if screens_dir:
             Pvi._screens_dir = Path(screens_dir)
             assert Pvi._screens_dir.is_dir(), "Screens directory must exist"
@@ -236,7 +236,7 @@ class Pvi:
             screens_dir_current_bobfiles = [
                 file
                 for file in Pvi._screens_dir.iterdir()
-                if str(file)[-4:] == ".bob" and file.is_file()
+                if file.suffix == ".bob" and file.is_file()
             ]
 
             if screens_dir_current_bobfiles:
@@ -245,9 +245,9 @@ class Pvi:
                         remove(file)
                 else:
                     raise FileExistsError(
-                        "Screens directory is not empty, if you want to run the ioc"
-                        "without generating bobfiles, use --skip-bobfile-gen-if-dir-"
-                        "not-empty"
+                        "Screens directory is not empty, if you want to run the ioc "
+                        "generating bobfiles, use --clear-bobfiles to delete the "
+                        "bobfiles from the existing --screens-dir."
                     )
 
             for device in devices:

--- a/src/pandablocks_ioc/ioc.py
+++ b/src/pandablocks_ioc/ioc.py
@@ -111,7 +111,12 @@ async def _create_softioc(
     create_softioc_task.add_done_callback(_when_finished)
 
 
-def create_softioc(client: AsyncioClient, record_prefix: str, screens_dir: str) -> None:
+def create_softioc(
+    client: AsyncioClient,
+    record_prefix: str,
+    screens_dir: Optional[str] = None,
+    skip_bobfile_gen_if_dir_not_empty: bool = False,
+) -> None:
     """Create a PythonSoftIOC from fields and attributes of a PandA.
 
     This function will introspect a PandA for all defined Blocks, Fields of each Block,
@@ -120,11 +125,14 @@ def create_softioc(client: AsyncioClient, record_prefix: str, screens_dir: str) 
     Args:
         client: The asyncio client to be used to read/write to of the PandA
         record_prefix: The string prefix used for creation of all records.
+        screens_dir: Directory to export generated bobfiles to,
+            if None then no bobfiles are generated.
     """
     # TODO: This needs to read/take in a YAML configuration file, for various aspects
     # e.g. the update() wait time between calling GetChanges
 
-    Pvi.set_screens_dir(screens_dir)
+    if screens_dir:
+        Pvi.set_screens_dir(screens_dir, skip_bobfile_gen_if_dir_not_empty)
 
     try:
         dispatcher = asyncio_dispatcher.AsyncioDispatcher()

--- a/src/pandablocks_ioc/ioc.py
+++ b/src/pandablocks_ioc/ioc.py
@@ -125,14 +125,18 @@ def create_softioc(
     Args:
         client: The asyncio client to be used to read/write to of the PandA
         record_prefix: The string prefix used for creation of all records.
+        screens_dir: The directory to export bobfiles to.
         clear_bobfiles: Can only be true if screens_dir is provided. Clears the
             screens_dir of bobfiles before creating new ones.
     """
     # TODO: This needs to read/take in a YAML configuration file, for various aspects
     # e.g. the update() wait time between calling GetChanges
 
+    if clear_bobfiles and not screens_dir:
+        raise ValueError("recieved clear_bobfiles=True with no screens_dir")
+
     if screens_dir:
-        Pvi.set_screens_dir(screens_dir, clear_bobfiles)
+        Pvi.configure_pvi(screens_dir, clear_bobfiles)
 
     try:
         dispatcher = asyncio_dispatcher.AsyncioDispatcher()

--- a/src/pandablocks_ioc/ioc.py
+++ b/src/pandablocks_ioc/ioc.py
@@ -115,7 +115,7 @@ def create_softioc(
     client: AsyncioClient,
     record_prefix: str,
     screens_dir: Optional[str] = None,
-    skip_bobfile_gen_if_dir_not_empty: bool = False,
+    clear_bobfiles: bool = False,
 ) -> None:
     """Create a PythonSoftIOC from fields and attributes of a PandA.
 
@@ -125,14 +125,14 @@ def create_softioc(
     Args:
         client: The asyncio client to be used to read/write to of the PandA
         record_prefix: The string prefix used for creation of all records.
-        screens_dir: Directory to export generated bobfiles to,
-            if None then no bobfiles are generated.
+        clear_bobfiles: Can only be true if screens_dir is provided. Clears the
+            screens_dir of bobfiles before creating new ones.
     """
     # TODO: This needs to read/take in a YAML configuration file, for various aspects
     # e.g. the update() wait time between calling GetChanges
 
     if screens_dir:
-        Pvi.set_screens_dir(screens_dir, skip_bobfile_gen_if_dir_not_empty)
+        Pvi.set_screens_dir(screens_dir, clear_bobfiles)
 
     try:
         dispatcher = asyncio_dispatcher.AsyncioDispatcher()

--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -280,7 +280,7 @@ def ioc_wrapper(
                 response_handler, child_conn=child_conn, command_queue=command_queue
             ),
             test_prefix,
-            bobfile_dir,
+            screens_dir=bobfile_dir,
         )
 
         # Leave this process running until its torn down by pytest

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -404,11 +404,12 @@ async def test_hdf5_file_writing(
     val = await caget(hdf5_test_prefix + ":FileName")
     assert val.tobytes().decode() == test_filename
 
-    # The example data contains 10000 data points, but we acquire only 1000
-    num_capture = 1000
-    assert await caget(HDF5_PREFIX + ":NumCapture") == 0
-    await caput(HDF5_PREFIX + ":NumCapture", num_capture, wait=True, timeout=TIMEOUT)
-    assert await caget(HDF5_PREFIX + ":NumCapture") == num_capture
+    # Only a single FrameData in the example data
+    assert await caget(hdf5_test_prefix + ":NumCapture") == 0
+    await caput(
+        hdf5_test_prefix + ":NumCapture", num_capture, wait=True, timeout=TIMEOUT
+    )
+    assert await caget(hdf5_test_prefix + ":NumCapture") == num_capture
 
     # The queue expects to see Capturing go 0 -> 1 -> 0 as Capture is enabled
     # and subsequently finishes

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -404,6 +404,8 @@ async def test_hdf5_file_writing(
     val = await caget(hdf5_test_prefix + ":FileName")
     assert val.tobytes().decode() == test_filename
 
+    # The example data contains 10000 data points, but we acquire only 1000
+    num_capture = 1000
     assert await caget(HDF5_PREFIX + ":NumCapture") == 0
     await caput(HDF5_PREFIX + ":NumCapture", num_capture, wait=True, timeout=TIMEOUT)
     assert await caget(HDF5_PREFIX + ":NumCapture") == num_capture

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -6,7 +6,6 @@ from asyncio import CancelledError
 from multiprocessing.connection import Connection
 from pathlib import Path
 from typing import AsyncGenerator, Generator
-from uuid import uuid4
 
 import h5py
 import numpy
@@ -17,6 +16,7 @@ from fixtures.mocked_panda import (
     TIMEOUT,
     MockedAsyncioClient,
     Rows,
+    append_random_uppercase,
     custom_logger,
     enable_codecov_multiprocess,
     get_multiprocessing_context,
@@ -36,12 +36,12 @@ from softioc import asyncio_dispatcher, builder, softioc
 
 from pandablocks_ioc._hdf_ioc import HDF5RecordController
 
-NAMESPACE_PREFIX = "HDF-RECORD-PREFIX-" + str(uuid4())[:4].upper()
+NAMESPACE_PREFIX = "HDF-RECORD-PREFIX"
 
 
 @pytest.fixture
 def new_random_hdf5_prefix():
-    test_prefix = NAMESPACE_PREFIX + "-" + str(uuid4())[:8].upper()
+    test_prefix = append_random_uppercase(NAMESPACE_PREFIX)
     hdf5_test_prefix = test_prefix + ":HDF5"
     return test_prefix, hdf5_test_prefix
 
@@ -271,7 +271,7 @@ def hdf5_subprocess_ioc_no_logging_check(
         child_conn.close()
         parent_conn.close()
         p.terminate()
-        p.join(10)
+        p.join(timeout=TIMEOUT)
         # Should never take anywhere near 10 seconds to terminate, it's just there
         # to ensure the test doesn't hang indefinitely during cleanup
 
@@ -301,7 +301,7 @@ def hdf5_subprocess_ioc(
                 child_conn.close()
                 parent_conn.close()
                 p.terminate()
-                p.join(10)
+                p.join(timeout=TIMEOUT)
                 # Should never take anywhere near 10 seconds to terminate,
                 # it's just there to ensure the test doesn't hang indefinitely
                 # during cleanup

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -37,7 +37,13 @@ from softioc import asyncio_dispatcher, builder, softioc
 from pandablocks_ioc._hdf_ioc import HDF5RecordController
 
 NAMESPACE_PREFIX = "HDF-RECORD-PREFIX-" + str(uuid4())[:4].upper()
-HDF5_PREFIX = NAMESPACE_PREFIX + ":HDF5"
+
+
+@pytest.fixture
+def new_random_hdf5_prefix():
+    test_prefix = NAMESPACE_PREFIX + "-" + str(uuid4())[:8].upper()
+    hdf5_test_prefix = test_prefix + ":HDF5"
+    return test_prefix, hdf5_test_prefix
 
 
 DUMP_FIELDS = [
@@ -206,12 +212,16 @@ def fast_dump_expected():
 
 
 @pytest_asyncio.fixture
-async def hdf5_controller(clear_records: None, standard_responses) -> AsyncGenerator:
+async def hdf5_controller(
+    clear_records: None, standard_responses, new_random_hdf5_prefix
+) -> AsyncGenerator:
     """Construct an HDF5 controller, ensuring we delete all records before
     and after the test runs, as well as ensuring the sockets opened in the HDF5
     controller are closed"""
 
-    hdf5_controller = HDF5RecordController(AsyncioClient("localhost"), NAMESPACE_PREFIX)
+    test_prefix, hdf5_test_prefix = new_random_hdf5_prefix
+
+    hdf5_controller = HDF5RecordController(AsyncioClient("localhost"), test_prefix)
     yield hdf5_controller
     # Give time for asyncio to fully close its connections
     await asyncio.sleep(0)
@@ -241,19 +251,22 @@ def subprocess_func(
 
 @pytest_asyncio.fixture
 def hdf5_subprocess_ioc_no_logging_check(
-    caplog, caplog_workaround, standard_responses
+    caplog, caplog_workaround, standard_responses, new_random_hdf5_prefix, clear_records
 ) -> Generator:
     """Create an instance of HDF5 class in its own subprocess, then start the IOC.
     Note you probably want to use `hdf5_subprocess_ioc` instead."""
+
+    test_prefix, hdf5_test_prefix = new_random_hdf5_prefix
+
     ctx = get_multiprocessing_context()
     parent_conn, child_conn = ctx.Pipe()
     p = ctx.Process(
-        target=subprocess_func, args=(NAMESPACE_PREFIX, standard_responses, child_conn)
+        target=subprocess_func, args=(test_prefix, standard_responses, child_conn)
     )
     try:
         p.start()
         select_and_recv(parent_conn)  # Wait for IOC to start up
-        yield
+        yield test_prefix, hdf5_test_prefix
     finally:
         child_conn.close()
         parent_conn.close()
@@ -264,21 +277,26 @@ def hdf5_subprocess_ioc_no_logging_check(
 
 
 @pytest_asyncio.fixture
-def hdf5_subprocess_ioc(caplog, caplog_workaround, standard_responses) -> Generator:
+def hdf5_subprocess_ioc(
+    caplog, caplog_workaround, standard_responses, new_random_hdf5_prefix, clear_records
+) -> Generator:
     """Create an instance of HDF5 class in its own subprocess, then start the IOC.
     When finished check logging logged no messages of WARNING or higher level."""
+
+    test_prefix, hdf5_test_prefix = new_random_hdf5_prefix
+
     with caplog.at_level(logging.WARNING):
         with caplog_workaround():
             ctx = get_multiprocessing_context()
             parent_conn, child_conn = ctx.Pipe()
             p = ctx.Process(
                 target=subprocess_func,
-                args=(NAMESPACE_PREFIX, standard_responses, child_conn),
+                args=(test_prefix, standard_responses, child_conn),
             )
             try:
                 p.start()
                 select_and_recv(parent_conn)  # Wait for IOC to start up
-                yield
+                yield test_prefix, hdf5_test_prefix
             finally:
                 child_conn.close()
                 parent_conn.close()
@@ -297,28 +315,31 @@ def hdf5_subprocess_ioc(caplog, caplog_workaround, standard_responses) -> Genera
 async def test_hdf5_ioc(hdf5_subprocess_ioc):
     """Run the HDF5 module as its own IOC and check the expected records are created,
     with some default values checked"""
-    val = await caget(HDF5_PREFIX + ":FilePath")
+
+    test_prefix, hdf5_test_prefix = hdf5_subprocess_ioc
+
+    val = await caget(hdf5_test_prefix + ":FilePath")
 
     # Default value of longStringOut is an array of a single NULL byte
     assert val.size == 1
 
     # Mix and match between CamelCase and UPPERCASE to check aliases work
-    val = await caget(HDF5_PREFIX + ":FILENAME")
+    val = await caget(hdf5_test_prefix + ":FILENAME")
     assert val.size == 1  # As above for longStringOut
 
-    val = await caget(HDF5_PREFIX + ":NumCapture")
+    val = await caget(hdf5_test_prefix + ":NumCapture")
     assert val == 0
 
-    val = await caget(HDF5_PREFIX + ":FlushPeriod")
+    val = await caget(hdf5_test_prefix + ":FlushPeriod")
     assert val == 1.0
 
-    val = await caget(HDF5_PREFIX + ":CAPTURE")
+    val = await caget(hdf5_test_prefix + ":CAPTURE")
     assert val == 0
 
-    val = await caget(HDF5_PREFIX + ":Status")
+    val = await caget(hdf5_test_prefix + ":Status")
     assert val == "OK"
 
-    val = await caget(HDF5_PREFIX + ":Capturing")
+    val = await caget(hdf5_test_prefix + ":Capturing")
     assert val == 0
 
 
@@ -332,20 +353,26 @@ async def test_hdf5_ioc_parameter_validate_works(hdf5_subprocess_ioc_no_logging_
     """Run the HDF5 module as its own IOC and check the _parameter_validate method
     does not stop updates, then stops when capture record is changed"""
 
+    test_prefix, hdf5_test_prefix = hdf5_subprocess_ioc_no_logging_check
+
     # EPICS bug means caputs always appear to succeed, so do a caget to prove it worked
-    await caput(HDF5_PREFIX + ":FilePath", _string_to_buffer("/new/path"), wait=True)
-    val = await caget(HDF5_PREFIX + ":FilePath")
+    await caput(
+        hdf5_test_prefix + ":FilePath", _string_to_buffer("/new/path"), wait=True
+    )
+    val = await caget(hdf5_test_prefix + ":FilePath")
     assert val.tobytes().decode() == "/new/path"
 
-    await caput(HDF5_PREFIX + ":FileName", _string_to_buffer("name.h5"), wait=True)
-    val = await caget(HDF5_PREFIX + ":FileName")
+    await caput(hdf5_test_prefix + ":FileName", _string_to_buffer("name.h5"), wait=True)
+    val = await caget(hdf5_test_prefix + ":FileName")
     assert val.tobytes().decode() == "name.h5"
 
-    await caput(HDF5_PREFIX + ":Capture", 1, wait=True)
-    assert await caget(HDF5_PREFIX + ":Capture") == 1
+    await caput(hdf5_test_prefix + ":Capture", 1, wait=True)
+    assert await caget(hdf5_test_prefix + ":Capture") == 1
 
-    await caput(HDF5_PREFIX + ":FilePath", _string_to_buffer("/second/path"), wait=True)
-    val = await caget(HDF5_PREFIX + ":FilePath")
+    await caput(
+        hdf5_test_prefix + ":FilePath", _string_to_buffer("/second/path"), wait=True
+    )
+    val = await caget(hdf5_test_prefix + ":FilePath")
     assert val.tobytes().decode() == "/new/path"  # put should have been stopped
 
 
@@ -354,26 +381,27 @@ async def test_hdf5_file_writing(
     hdf5_subprocess_ioc, tmp_path: Path, caplog, num_capture
 ):
     """Test that an HDF5 file is written when Capture is enabled"""
+
+    test_prefix, hdf5_test_prefix = hdf5_subprocess_ioc
     test_dir = str(tmp_path) + "\0"
     test_filename = "test.h5\0"
-    # HDF5_PREFIX = TEST_PREFIX + ":HDF5"
 
     await caput(
-        HDF5_PREFIX + ":FilePath",
+        hdf5_test_prefix + ":FilePath",
         _string_to_buffer(str(test_dir)),
         wait=True,
         timeout=TIMEOUT,
     )
-    val = await caget(HDF5_PREFIX + ":FilePath")
+    val = await caget(hdf5_test_prefix + ":FilePath")
     assert val.tobytes().decode() == test_dir
 
     await caput(
-        HDF5_PREFIX + ":FileName",
+        hdf5_test_prefix + ":FileName",
         _string_to_buffer(test_filename),
         wait=True,
         timeout=TIMEOUT,
     )
-    val = await caget(HDF5_PREFIX + ":FileName")
+    val = await caget(hdf5_test_prefix + ":FileName")
     assert val.tobytes().decode() == test_filename
 
     assert await caget(HDF5_PREFIX + ":NumCapture") == 0
@@ -384,14 +412,14 @@ async def test_hdf5_file_writing(
     # and subsequently finishes
     capturing_queue: asyncio.Queue = asyncio.Queue()
     m = camonitor(
-        HDF5_PREFIX + ":Capturing",
+        hdf5_test_prefix + ":Capturing",
         capturing_queue.put,
     )
 
     # Initially Capturing should be 0
     assert await capturing_queue.get() == 0
 
-    await caput(HDF5_PREFIX + ":Capture", 1, wait=True, timeout=TIMEOUT)
+    await caput(hdf5_test_prefix + ":Capture", 1, wait=True, timeout=TIMEOUT)
 
     assert await capturing_queue.get() == 1
 
@@ -401,8 +429,8 @@ async def test_hdf5_file_writing(
     m.close()
 
     # Close capture, thus closing hdf5 file
-    await caput(HDF5_PREFIX + ":Capture", 0, wait=True)
-    assert await caget(HDF5_PREFIX + ":Capture") == 0
+    await caput(hdf5_test_prefix + ":Capture", 0, wait=True)
+    assert await caget(hdf5_test_prefix + ":Capture") == 0
 
     # Confirm file contains data we expect
     hdf_file = h5py.File(tmp_path / test_filename[:-1], "r")

--- a/tests/test_pvaccess.py
+++ b/tests/test_pvaccess.py
@@ -1,8 +1,8 @@
+import asyncio
 import collections
 from typing import OrderedDict
 
 import numpy
-from fixtures.mocked_panda import TEST_PREFIX
 from numpy import ndarray
 from p4p import Value
 from p4p.client.thread import Context
@@ -16,10 +16,18 @@ async def test_table_column_info(
 ):
     """Test that the table columns have the expected PVAccess information in the
     right order"""
-
+    (
+        tmp_path,
+        child_conn,
+        response_handler,
+        command_queue,
+        test_prefix,
+    ) = mocked_panda_standard_responses
     ctxt = Context("pva", nt=False)
 
-    table_value: Value = ctxt.get(TEST_PREFIX + ":SEQ:TABLE")
+    # Give the ioc some time to start up.
+    await asyncio.sleep(1)
+    table_value: Value = ctxt.get(test_prefix + ":SEQ:TABLE")
 
     for (actual_name, actual_value), (expected_name, expected_value) in zip(
         table_value.todict(wrapper=collections.OrderedDict)["value"].items(),

--- a/tests/test_pvaccess.py
+++ b/tests/test_pvaccess.py
@@ -1,4 +1,3 @@
-import asyncio
 import collections
 from typing import OrderedDict
 
@@ -25,8 +24,6 @@ async def test_table_column_info(
     ) = mocked_panda_standard_responses
     ctxt = Context("pva", nt=False)
 
-    # Give the ioc some time to start up.
-    await asyncio.sleep(1)
     table_value: Value = ctxt.get(test_prefix + ":SEQ:TABLE")
 
     for (actual_name, actual_value), (expected_name, expected_value) in zip(

--- a/tests/test_unit_testing_structure.py
+++ b/tests/test_unit_testing_structure.py
@@ -1,5 +1,4 @@
 from aioca import caget
-from fixtures.mocked_panda import TEST_PREFIX
 
 
 def test_conftest_loads_fixtures_from_other_files(table_fields):
@@ -9,8 +8,14 @@ def test_conftest_loads_fixtures_from_other_files(table_fields):
 
 async def test_fake_panda_and_ioc(mocked_panda_standard_responses):
     """Tests that the test ioc launches and the PVs are broadcasted"""
-    tmp_path, child_conn, responses, command_queue = mocked_panda_standard_responses
+    (
+        tmp_path,
+        child_conn,
+        responses,
+        command_queue,
+        test_prefix,
+    ) = mocked_panda_standard_responses
 
     # PVs are broadcast
-    gate_delay = await caget(f"{TEST_PREFIX}:PCAP:GATE:DELAY")
+    gate_delay = await caget(f"{test_prefix}:PCAP:GATE:DELAY")
     assert gate_delay == 1


### PR DESCRIPTION
Closes #41 

I think adding a new flag as mentioned [here](https://github.com/PandABlocks/PandABlocks-ioc/pull/29#issuecomment-1708670952) could lead to some issues with pvi... We could end up with bobfiles the `screen-dir` that unintuitively  aren't actually matched to the PVs of the IOC currently running:

Running
```PandABlocks-ioc softioc 172.23.252.201 TEST-PREFIX --screens-dir=screens --skip-bobfile-en-if-dir-not-empty```
in the case where screens isn't empty and the panda has changed since the `.bob` have been created will lead to a gui that isn't necessarily up to date with the pvi of the ioc.


I think it would be cleaner to have `--overwrite-files`, but it would depend on if there's really a use case for this.