### PR TITLE
Changed enum values back to uint8 before updating the table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click",
     "h5py",
     "softioc>=4.4.0",
-    "pandablocks>=0.5.2",
+    "pandablocks@git+https://github.com/evalott100/PandABlocks-client@restore_enum_behaviour",
     "pvi>=0.5",
 ] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click",
     "h5py",
     "softioc>=4.4.0",
-    "pandablocks>=0.5.1",
+    "pandablocks>=0.5.2",
     "pvi>=0.5",
 ] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click",
     "h5py",
     "softioc>=4.4.0",
-    "pandablocks@git+https://github.com/evalott100/PandABlocks-client@restore_enum_behaviour",
+    "pandablocks>=0.5.3",
     "pvi>=0.5",
 ] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]

--- a/src/pandablocks_ioc/_tables.py
+++ b/src/pandablocks_ioc/_tables.py
@@ -675,10 +675,6 @@ class TableUpdater:
 
         try:
             scalar_val = waveform_data[index]
-            if labels:
-                # mbbi/o records must use the numeric index
-                if isinstance(scalar_val, str):
-                    scalar_val = labels.index(scalar_val)
             sev = alarm.NO_ALARM
         except IndexError as e:
             logging.warning(

--- a/src/pandablocks_ioc/_tables.py
+++ b/src/pandablocks_ioc/_tables.py
@@ -721,10 +721,7 @@ class TableUpdater:
 
         # alarm value is ignored if severity = NO_ALARM. Softioc also defaults
         # alarm value to UDF_ALARM, but I'm specifying it for clarity.
-        if labels:
-            scalar_record.set(scalar_val, severity=sev, alarm=alarm.UDF_ALARM)
-        else:
-            scalar_record.set(scalar_val, severity=sev, alarm=alarm.UDF_ALARM)
+        scalar_record.set(scalar_val, severity=sev, alarm=alarm.UDF_ALARM)
 
     def _update_index_drvh(self, data: UnpackedArray):
         """Set the DRVH value of the index record based on the newly set data length"""

--- a/src/pandablocks_ioc/_tables.py
+++ b/src/pandablocks_ioc/_tables.py
@@ -358,8 +358,6 @@ class TableUpdater:
                 if len(field_data[field_name]) > 0
                 else 0
             )
-            if field_details.labels and isinstance(initial_value, str):
-                initial_value = field_details.labels.index(initial_value)
 
             # Three possible field types, do per-type config
             if field_details.subtype == "int":
@@ -679,7 +677,8 @@ class TableUpdater:
             scalar_val = waveform_data[index]
             if labels:
                 # mbbi/o records must use the numeric index
-                scalar_val = labels.index(scalar_val)
+                if isinstance(scalar_val, str):
+                    scalar_val = labels.index(scalar_val)
             sev = alarm.NO_ALARM
         except IndexError as e:
             logging.warning(

--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -153,6 +153,7 @@ class ResponseHandler:
         key = command_to_key(command)
 
         if key not in self.responses:
+            print("aeoifuhzdlisgnszknf")
             raise RuntimeError(
                 f"Error in mocked panda, command {command} was passed in, "
                 f"the mocked responses defined for are: {[self.responses.keys()]}"
@@ -470,7 +471,7 @@ def multiple_seq_responses(table_field_info, table_data_1, table_data_2):
         ),
         command_to_key(GetBlockInfo(skip_description=False)): repeat(
             {
-                "SEQ": BlockInfo(number=3, description="SEQ Desc"),
+                "SEQ": BlockInfo(number=4, description="SEQ Desc"),
             }
         ),
         command_to_key(
@@ -486,11 +487,13 @@ def multiple_seq_responses(table_field_info, table_data_1, table_data_2):
                     "*METADATA.LABEL_SEQ1": "SeqMetadataLabel",
                     "*METADATA.LABEL_SEQ2": "SeqMetadataLabel",
                     "*METADATA.LABEL_SEQ3": "SeqMetadataLabel",
+                    "*METADATA.LABEL_SEQ4": "SeqMetadataLabel",
                 },
                 multiline_values={
                     "SEQ1.TABLE": table_data_1,
                     "SEQ2.TABLE": table_data_2,
                     "SEQ3.TABLE": [],
+                    "SEQ4.TABLE": [],
                 },
             ),
             respond_with_no_changes(number_of_iterations=10),

--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -472,7 +472,20 @@ def multiple_seq_responses(table_field_info, table_data_1, table_data_2):
         command_to_key(
             Put(
                 field="SEQ4.TABLE",
-                value=["0", "0", "0", "0", "1", "0", "0", "0", "0", "0", "0", "0"],
+                value=[
+                    "2457862149",
+                    "4294967291",
+                    "100",
+                    "0",
+                    "269877248",
+                    "678",
+                    "0",
+                    "55",
+                    "4293968720",
+                    "0",
+                    "9",
+                    "9999",
+                ],
             )
         ): repeat(None),
         command_to_key(

--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -470,7 +470,7 @@ def multiple_seq_responses(table_field_info, table_data_1, table_data_2):
         ),
         command_to_key(GetBlockInfo(skip_description=False)): repeat(
             {
-                "SEQ": BlockInfo(number=2, description="SEQ Desc"),
+                "SEQ": BlockInfo(number=3, description="SEQ Desc"),
             }
         ),
         command_to_key(
@@ -485,10 +485,19 @@ def multiple_seq_responses(table_field_info, table_data_1, table_data_2):
                 values={
                     "*METADATA.LABEL_SEQ1": "SeqMetadataLabel",
                     "*METADATA.LABEL_SEQ2": "SeqMetadataLabel",
+                    "*METADATA.LABEL_SEQ3": "SeqMetadataLabel",
                 },
                 multiline_values={
                     "SEQ1.TABLE": table_data_1,
                     "SEQ2.TABLE": table_data_2,
+                    "SEQ3.TABLE": [],
+                },
+            ),
+            respond_with_no_changes(number_of_iterations=10),
+            changes_iterator_wrapper(
+                values={},
+                multiline_values={
+                    "SEQ3.TABLE": table_data_1,
                 },
             ),
             # Keep the panda active with no changes until pytest tears it down

--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -60,6 +60,11 @@ def new_random_test_prefix():
     return append_random_uppercase(TEST_PREFIX)
 
 
+def multiprocessing_queue_to_list(queue: Queue):
+    queue.put(None)
+    return list(iter(queue.get, None))
+
+
 @pytest_asyncio.fixture
 def mocked_time_record_updater(
     new_random_test_prefix,
@@ -153,7 +158,6 @@ class ResponseHandler:
         key = command_to_key(command)
 
         if key not in self.responses:
-            print("aeoifuhzdlisgnszknf")
             raise RuntimeError(
                 f"Error in mocked panda, command {command} was passed in, "
                 f"the mocked responses defined for are: {[self.responses.keys()]}"
@@ -459,6 +463,31 @@ def multiple_seq_responses(table_field_info, table_data_1, table_data_2):
                     "0",
                     "55",
                     "4293918721",
+                    "0",
+                    "9",
+                    "9999",
+                ],
+            )
+        ): repeat(None),
+        command_to_key(
+            Put(
+                field="SEQ4.TABLE",
+                value=["0", "0", "0", "0", "1", "0", "0", "0", "0", "0", "0", "0"],
+            )
+        ): repeat(None),
+        command_to_key(
+            Put(
+                field="SEQ3.TABLE",
+                value=[
+                    "2457862144",
+                    "4294967291",
+                    "100",
+                    "0",
+                    "269877249",
+                    "678",
+                    "0",
+                    "55",
+                    "4293918720",
                     "0",
                     "9",
                     "9999",

--- a/tests/fixtures/panda_data.py
+++ b/tests/fixtures/panda_data.py
@@ -212,7 +212,7 @@ def table_unpacked_data(
     """The unpacked equivalent of table_data"""
     array_values: List[ndarray] = [
         array([5, 0, 50000], dtype=uint16),
-        # Below labels correspond to label values []"Immediate", "BITC=1", "Immediate"]
+        # Below labels correspond to label values ["Immediate", "BITC=1", "Immediate"]
         array([0, 6, 0], dtype=uint8),
         array([-5, 678, 0], dtype=int32),
         array([100, 0, 9], dtype=uint32),

--- a/tests/fixtures/panda_data.py
+++ b/tests/fixtures/panda_data.py
@@ -212,8 +212,8 @@ def table_unpacked_data(
     """The unpacked equivalent of table_data"""
     array_values: List[ndarray] = [
         array([5, 0, 50000], dtype=uint16),
-        # Below labels correspond to numeric values [0, 6, 0]
-        array(["Immediate", "BITC=1", "Immediate"], dtype="<U9"),
+        # Below labels correspond to label values []"Immediate", "BITC=1", "Immediate"]
+        array([0, 6, 0], dtype=uint8),
         array([-5, 678, 0], dtype=int32),
         array([100, 0, 9], dtype=uint32),
         array([0, 1, 1], dtype=uint8),

--- a/tests/fixtures/panda_data.py
+++ b/tests/fixtures/panda_data.py
@@ -212,8 +212,8 @@ def table_unpacked_data(
     """The unpacked equivalent of table_data"""
     array_values: List[ndarray] = [
         array([5, 0, 50000], dtype=uint16),
-        # Below labels correspond to label values ["Immediate", "BITC=1", "Immediate"]
-        array([0, 6, 0], dtype=uint8),
+        # Below labels correspond to label values
+        array(["Immediate", "BITC=1", "Immediate"]),
         array([-5, 678, 0], dtype=int32),
         array([100, 0, 9], dtype=uint32),
         array([0, 1, 1], dtype=uint8),

--- a/tests/fixtures/panda_data.py
+++ b/tests/fixtures/panda_data.py
@@ -212,7 +212,6 @@ def table_unpacked_data(
     """The unpacked equivalent of table_data"""
     array_values: List[ndarray] = [
         array([5, 0, 50000], dtype=uint16),
-        # Below labels correspond to label values
         array(["Immediate", "BITC=1", "Immediate"]),
         array([-5, 678, 0], dtype=int32),
         array([100, 0, 9], dtype=uint32),

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -6,7 +6,7 @@ import numpy
 import numpy.testing
 import pytest
 from aioca import caget, camonitor, caput
-from fixtures.mocked_panda import TIMEOUT, command_to_key
+from fixtures.mocked_panda import TIMEOUT, command_to_key, multiprocessing_queue_to_list
 from mock import AsyncMock, patch
 from mock.mock import MagicMock, PropertyMock, call
 from numpy import ndarray
@@ -14,8 +14,6 @@ from pandablocks.asyncio import AsyncioClient
 from pandablocks.commands import GetMultiline, Put
 from pandablocks.responses import TableFieldDetails, TableFieldInfo
 from softioc import alarm, fields
-
-from fixtures.mocked_panda import multiprocessing_queue_to_list
 
 from pandablocks_ioc._tables import (
     TableFieldRecordContainer,

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -138,11 +138,8 @@ async def test_create_softioc_update_table(
 
         # And check some other columns too
         curr_val = await caget(test_prefix + ":SEQ:TABLE:TRIGGER")
-        assert numpy.array_equal(
-            curr_val,
-            # Numeric values: [0, 0, 0, 9, 12]
-            ["Immediate", "Immediate", "Immediate", "POSB>=POSITION", "POSC<=POSITION"],
-        )
+        # ["Immediate", "Immediate", "Immediate", "POSB>=POSITION", "POSC<=POSITION"],
+        assert numpy.array_equal(curr_val, [0, 0, 0, 9, 12])
 
         curr_val = await caget(test_prefix + ":SEQ:TABLE:POSITION")
         assert numpy.array_equal(curr_val, [-5, 0, 0, 444444, -99])
@@ -260,8 +257,7 @@ async def test_create_softioc_table_update_send_to_panda(
 
 
 async def test_create_softioc_update_table_index(
-    mocked_panda_standard_responses,
-    table_unpacked_data,
+    mocked_panda_standard_responses, table_unpacked_data, table_fields
 ):
     """Test that updating the INDEX updates the SCALAR values"""
     (
@@ -290,7 +286,10 @@ async def test_create_softioc_update_table_index(
         curr_val = await asyncio.wait_for(repeats_queue.get(), TIMEOUT)
         assert curr_val == table_unpacked_data["REPEATS"][index_val]
         curr_val = await asyncio.wait_for(trigger_queue.get(), TIMEOUT)
-        assert curr_val == table_unpacked_data["TRIGGER"][index_val]
+        assert (
+            curr_val
+            == table_fields["TRIGGER"].labels[table_unpacked_data["TRIGGER"][index_val]]
+        )
 
         # Now set a new INDEX
         index_val = 1
@@ -300,7 +299,10 @@ async def test_create_softioc_update_table_index(
         curr_val = await asyncio.wait_for(repeats_queue.get(), TIMEOUT)
         assert curr_val == table_unpacked_data["REPEATS"][index_val]
         curr_val = await asyncio.wait_for(trigger_queue.get(), TIMEOUT)
-        assert curr_val == table_unpacked_data["TRIGGER"][index_val]
+        assert (
+            curr_val
+            == table_fields["TRIGGER"].labels[table_unpacked_data["TRIGGER"][index_val]]
+        )
 
     finally:
         repeats_monitor.close()


### PR DESCRIPTION
Closes #55 

Added a test to add to the panda table after initially leaving it blank

`update_table` will currently not work for enum values in the table since they're `List[str]` and have to be converted back to their integer index values.

Added a test to `update_table` for a table which is `[]` on ioc start up, then is added to on the panda side.