### PR TITLE
Made each group member self trigger

### DIFF
--- a/src/pandablocks_ioc/_pvi.py
+++ b/src/pandablocks_ioc/_pvi.py
@@ -86,13 +86,15 @@ def add_pvi_info(
         component = SignalR(record_name, record_name, TextRead())
         access = "r"
     block, field = record_name.split(":", maxsplit=1)
+    block_name_suffixed = f"pvi.{field.lower().replace(':', '_')}.{access}"
     record.add_info(
         "Q:group",
         {
             RecordName(f"{block}:PVI"): {
-                f"pvi.{field.lower().replace(':', '_')}.{access}": {
+                block_name_suffixed: {
                     "+channel": "NAME",
                     "+type": "plain",
+                    "+trigger": block_name_suffixed,
                 }
             }
         },
@@ -202,13 +204,15 @@ class Pvi:
                 pvi_record_name + "_PV",
                 initial_value=RecordName(pvi_record_name),
             )
+            block_name_suffixed = f"pvi.{block_name.lower()}.d"
             block_pvi.add_info(
                 "Q:group",
                 {
                     RecordName("PVI"): {
-                        f"pvi.{block_name.lower()}.d": {
+                        block_name_suffixed: {
                             "+channel": "VAL",
                             "+type": "plain",
+                            "+trigger": block_name_suffixed,
                         }
                     }
                 },


### PR DESCRIPTION
Closes #44 
Fixed warnings using the method mentioned here https://github.com/mdavidsaver/pvxs/issues/59#issuecomment-1766675262

We still have the warnings
```
INFO:Description for <SOME:PV:NAME> longer than EPICS limit of 40 characters. It will be truncated. Description: <A LONG DESCRIPTION>
```

but these won't be handled in this PR.