### PR TITLE
Fixing the occasional errors in tests

### DIFF
--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -795,7 +795,7 @@ def standard_responses(table_field_info, table_data_1, table_data_2):
             ),
             # 0.5 seconds of no changes in case the ioc setup completes
             # before the test starts
-            respond_with_no_changes(number_of_iterations=10),
+            respond_with_no_changes(number_of_iterations=15),
             changes_iterator_wrapper(
                 values={
                     "PCAP.TRIG_EDGE": "Either",

--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -671,6 +671,57 @@ def faulty_multiple_pcap_responses():
 
 
 @pytest.fixture
+def standard_responses_no_panda_update(table_field_info, table_data_1):
+    """
+    Used to test if the softioc can be started.
+    """
+    return {
+        command_to_key(GetFieldInfo(block="PCAP", extended_metadata=True)): repeat(
+            {
+                "TRIG_EDGE": EnumFieldInfo(
+                    type="param",
+                    subtype="enum",
+                    description="Trig Edge Desc",
+                    labels=["Rising", "Falling", "Either"],
+                ),
+                "GATE": BitMuxFieldInfo(
+                    type="bit_mux",
+                    subtype=None,
+                    description="Gate Desc",
+                    max_delay=100,
+                    labels=["TTLIN1.VAL", "INENC1.A", "CLOCK1.OUT"],
+                ),
+            }
+        ),
+        command_to_key(GetFieldInfo(block="SEQ", extended_metadata=True)): repeat(
+            {"TABLE": table_field_info}
+        ),
+        command_to_key(GetBlockInfo(skip_description=False)): repeat(
+            {
+                "PCAP": BlockInfo(number=1, description="PCAP Desc"),
+                "SEQ": BlockInfo(number=1, description="SEQ Desc"),
+            }
+        ),
+        # Changes are given at 10Hz, the changes provided are used for many
+        # different tests
+        command_to_key(GetChanges(group=ChangeGroup.ALL, get_multiline=True)): chain(
+            # Initial value of every field
+            changes_iterator_wrapper(
+                values={
+                    "PCAP.TRIG_EDGE": "Falling",
+                    "PCAP.GATE": "CLOCK1.OUT",
+                    "PCAP.GATE.DELAY": "1",
+                    "PCAP.ARM": "0",
+                    "*METADATA.LABEL_PCAP1": "PcapMetadataLabel",
+                },
+                multiline_values={"SEQ.TABLE": table_data_1},
+            ),
+            respond_with_no_changes(),
+        ),
+    }
+
+
+@pytest.fixture
 def standard_responses(table_field_info, table_data_1, table_data_2):
     """
     Used by MockedAsyncioClient to generate panda responses to the ioc's commands.
@@ -845,6 +896,30 @@ def mocked_panda_standard_responses(
     clear_records,
 ) -> Generator[Tuple[Path, Connection, ResponseHandler, Queue, str], None, None]:
     response_handler = ResponseHandler(standard_responses)
+
+    yield from create_subprocess_ioc_and_responses(
+        response_handler,
+        tmp_path,
+        new_random_test_prefix,
+        caplog,
+        caplog_workaround,
+        table_field_info,
+        table_fields,
+    )
+
+
+@pytest.fixture
+def mocked_panda_standard_responses_no_panda_update(
+    standard_responses_no_panda_update,
+    new_random_test_prefix,
+    tmp_path: Path,
+    caplog,
+    caplog_workaround,
+    table_field_info,
+    table_fields,
+    clear_records,
+) -> Generator[Tuple[Path, Connection, ResponseHandler, Queue, str], None, None]:
+    response_handler = ResponseHandler(standard_responses_no_panda_update)
 
     yield from create_subprocess_ioc_and_responses(
         response_handler,

--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -538,7 +538,7 @@ def multiple_seq_responses(table_field_info, table_data_1, table_data_2):
                     "SEQ4.TABLE": [],
                 },
             ),
-            respond_with_no_changes(number_of_iterations=10),
+            respond_with_no_changes(number_of_iterations=50),
             changes_iterator_wrapper(
                 values={},
                 multiline_values={

--- a/tests/test_ioc_system.py
+++ b/tests/test_ioc_system.py
@@ -89,7 +89,7 @@ async def test_introspect_panda(
 
 
 async def test_create_softioc_system(
-    mocked_panda_standard_responses,
+    mocked_panda_standard_responses_no_panda_update,
     table_unpacked_data: OrderedDict[EpicsName, ndarray],
 ):
     """Top-level system test of the entire program, using some pre-canned data. Tests
@@ -102,7 +102,7 @@ async def test_create_softioc_system(
         response_handler,
         command_queue,
         test_prefix,
-    ) = mocked_panda_standard_responses
+    ) = mocked_panda_standard_responses_no_panda_update
 
     for field_name, expected_array in table_unpacked_data.items():
         actual_array = await caget(test_prefix + ":SEQ:TABLE:" + field_name)

--- a/tests/test_ioc_system.py
+++ b/tests/test_ioc_system.py
@@ -104,13 +104,13 @@ async def test_create_softioc_system(
         test_prefix,
     ) = mocked_panda_standard_responses
 
-    assert await caget(test_prefix + ":PCAP:TRIG_EDGE") == 1  # == Falling
-    assert await caget(test_prefix + ":PCAP:GATE") == "CLOCK1.OUT"
-    assert await caget(test_prefix + ":PCAP:GATE:DELAY") == 1
-
     for field_name, expected_array in table_unpacked_data.items():
         actual_array = await caget(test_prefix + ":SEQ:TABLE:" + field_name)
         assert numpy.array_equal(actual_array, expected_array)
+
+    assert await caget(test_prefix + ":PCAP:TRIG_EDGE") == 1  # == Falling
+    assert await caget(test_prefix + ":PCAP:GATE") == "CLOCK1.OUT"
+    assert await caget(test_prefix + ":PCAP:GATE:DELAY") == 1
 
     pcap1_label = await caget(test_prefix + ":PCAP:LABEL")
     assert numpy.array_equal(


### PR DESCRIPTION
A couple of tests fail occasionally:

* `test_create_softioc_system` sometimes cagets `SEQ.TABLE` fields part way through the panda-side update of `SEQ.TABLE`. To fix this, the caget has been moved to the start of the test and more time has been added before `SEQ.TABLE` is updated in the mocked panda.
* `test_table_column_info` would fail because
    * the test process was too fast: pva would try to fetch values before panda introspection
    * the mocked panda process was too fast: by the time the pva context had been updated the mocked panda would have altered its table
    * To fix the former we used a pva monitor instead of a caget, timing out at `TIMEOUT`, to fix the latter we used a different mocked panda which doesn't update its tables. We've also changed to the asyncio p4p client.
* During testing for the above two tests, another test failed: `test_non_defined_seq_table_can_be_added_to_panda_side` this was because very rarely the panda subprocess was too fast and had already changed `SEQ3` to have values.
    * To fix this we'll give the panda 50 updates before it changes the value of `SEQ3` rather than 10. 


Tested locally with
```
for i in {1..50}; do echo $i; pytest | grep failed; done
```

to ensure no failures,

tested on the CI 10 times.