### PR TITLE
Changed `navigation_with_keys` to False

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,6 +174,7 @@ html_theme_options = dict(
             url=f"https://github.com/{github_user}/{github_repo}/releases",
         )
     ],
+    navigation_with_keys=False,
 )
 
 # A dictionary of values to pass into the template engine’s context for all pages


### PR DESCRIPTION
Explicitly changes navigation_with_keys to False
Docs CI fails because of a warning that navigation_with_keys will be defaulted to False in the next sphinx release. This prevents the warning.