### PR TITLE
pinned pvi version to 0.5

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install python packages
         uses: ./.github/actions/install_requirements
         with:
+          python_version: "3.11"
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install python packages
         uses: ./.github/actions/install_requirements
         with:
+          python_version: "3.11"
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "h5py",
     "softioc>=4.4.0",
     "pandablocks>=0.5.3",
-    "pvi>=0.5",
+    "pvi==0.5",
 ] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]
 license.file = "LICENSE"


### PR DESCRIPTION
Closes #68 

Pinning pvi until we update the pvi code to account for `DeviceRefs`

Also pin linter and docs CI to 3.11. We'll have to do this [unitl p4p](https://github.com/mdavidsaver/p4p/pull/126) fixes their install for 3.12. Then we can bump up our own version.