### PR TITLE
Adjusted to use the new pydantic pvi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "h5py",
     "softioc>=4.4.0",
     "pandablocks>=0.5.3",
-    "pvi>=0.6",
+    "pvi~=0.7.0",
 ] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/pandablocks_ioc/_tables.py
+++ b/src/pandablocks_ioc/_tables.py
@@ -25,6 +25,7 @@ from ._types import (
     RecordInfo,
     RecordValue,
     epics_to_panda_name,
+    epics_to_pvi_name,
     trim_description,
 )
 
@@ -56,7 +57,7 @@ class TableFieldRecordContainer:
 
 
 def make_bit_order(
-    table_field_records: Dict[str, TableFieldRecordContainer]
+    table_field_records: Dict[str, TableFieldRecordContainer],
 ) -> Dict[str, TableFieldRecordContainer]:
     return dict(
         sorted(table_field_records.items(), key=lambda item: item[1].field.bit_low)
@@ -144,12 +145,14 @@ class TableUpdater:
         )
         self.all_values_dict = all_values_dict
 
+        pvi_table_name = epics_to_pvi_name(table_name)
+
         # The PVI group to put all records into
         pvi_group = PviGroup.PARAMETERS
         Pvi.add_pvi_info(
             table_name,
             pvi_group,
-            SignalRW(table_name, table_name, TableWrite([])),
+            SignalRW(name=pvi_table_name, pv=table_name, widget=TableWrite(widgets=[])),
         )
 
         # Note that the table_updater's table_fields are guaranteed sorted in bit order,
@@ -216,10 +219,11 @@ class TableUpdater:
             initial_value=TableModeEnum.VIEW.value,
             on_update=self.update_mode,
         )
+        pvi_name = epics_to_pvi_name(mode_record_name)
         Pvi.add_pvi_info(
             mode_record_name,
             pvi_group,
-            SignalRW(mode_record_name, mode_record_name, ComboBox()),
+            SignalRW(name=pvi_name, pv=mode_record_name, widget=ComboBox()),
         )
 
         self.mode_record_info = RecordInfo(lambda x: x, labels, False)

--- a/tests/test-bobfiles/HDF5.bob
+++ b/tests/test-bobfiles/HDF5.bob
@@ -34,7 +34,7 @@
     <transparent>true</transparent>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>HDF5: File Path</text>
+      <text>Filepath</text>
       <x>0</x>
       <y>0</y>
       <width>250</width>
@@ -52,7 +52,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>HDF5: File Name</text>
+      <text>Filename</text>
       <x>0</x>
       <y>25</y>
       <width>250</width>
@@ -70,7 +70,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>HDF5: Num Capture</text>
+      <text>Numcapture</text>
       <x>0</x>
       <y>50</y>
       <width>250</width>
@@ -87,7 +87,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>HDF5: Flush Period</text>
+      <text>Flushperiod</text>
       <x>0</x>
       <y>75</y>
       <width>250</width>
@@ -104,7 +104,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>HDF5: Capture</text>
+      <text>Capture</text>
       <x>0</x>
       <y>100</y>
       <width>250</width>
@@ -129,7 +129,7 @@
     <transparent>true</transparent>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>HDF5: Status</text>
+      <text>Status</text>
       <x>0</x>
       <y>0</y>
       <width>250</width>
@@ -150,7 +150,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>HDF5: Capturing</text>
+      <text>Capturing</text>
       <x>0</x>
       <y>25</y>
       <width>250</width>

--- a/tests/test-bobfiles/PCAP.bob
+++ b/tests/test-bobfiles/PCAP.bob
@@ -34,7 +34,7 @@
     <transparent>true</transparent>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>PCAP: LABEL</text>
+      <text>Label</text>
       <x>0</x>
       <y>0</y>
       <width>250</width>
@@ -52,7 +52,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>PCAP: ARM</text>
+      <text>Arm</text>
       <x>0</x>
       <y>25</y>
       <width>250</width>
@@ -94,7 +94,7 @@
     </widget>
     <widget type="led" version="2.0.0">
       <name>LED</name>
-      <pv_name>TEST_PREFIX:</pv_name>
+      <pv_name>TEST_PREFIX:PCAP:ARM</pv_name>
       <x>350</x>
       <y>25</y>
       <width>20</width>
@@ -102,7 +102,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>PCAP: GATE</text>
+      <text>Gate</text>
       <x>0</x>
       <y>50</y>
       <width>250</width>
@@ -120,7 +120,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>PCAP: GATE: DELAY</text>
+      <text>Delay</text>
       <x>0</x>
       <y>75</y>
       <width>250</width>
@@ -145,7 +145,7 @@
     <transparent>true</transparent>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>PCAP: TRIG_ EDGE</text>
+      <text>Trig Edge</text>
       <x>0</x>
       <y>0</y>
       <width>250</width>

--- a/tests/test-bobfiles/PULSE.bob
+++ b/tests/test-bobfiles/PULSE.bob
@@ -34,7 +34,7 @@
     <transparent>true</transparent>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>PULSE: DELAY</text>
+      <text>Delay</text>
       <x>0</x>
       <y>0</y>
       <width>250</width>
@@ -51,7 +51,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>PULSE: DELAY: UNITS</text>
+      <text>Units</text>
       <x>0</x>
       <y>25</y>
       <width>250</width>

--- a/tests/test-bobfiles/PandA.bob
+++ b/tests/test-bobfiles/PandA.bob
@@ -26,7 +26,7 @@
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
   <widget type="group" version="2.0.0">
-    <name>POSITIONS_ TABLE</name>
+    <name>Positions Table</name>
     <x>5</x>
     <y>30</y>
     <width>36</width>

--- a/tests/test-bobfiles/SEQ.bob
+++ b/tests/test-bobfiles/SEQ.bob
@@ -42,7 +42,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>SEQ: TABLE: MODE</text>
+      <text>Mode</text>
       <x>0</x>
       <y>205</y>
       <width>250</width>

--- a/tests/test-bobfiles/index.bob
+++ b/tests/test-bobfiles/index.bob
@@ -27,7 +27,7 @@
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label</name>
-    <text>PCAP: PVI</text>
+    <text>PCAP</text>
     <x>23</x>
     <y>30</y>
     <width>250</width>
@@ -42,7 +42,7 @@
         <description>Open Display</description>
       </action>
     </actions>
-    <text>PCAP: PVI</text>
+    <text>PCAP</text>
     <x>278</x>
     <y>30</y>
     <width>125</width>
@@ -51,7 +51,7 @@
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label</name>
-    <text>HDF5: PVI</text>
+    <text>HDF5</text>
     <x>23</x>
     <y>55</y>
     <width>250</width>
@@ -66,7 +66,7 @@
         <description>Open Display</description>
       </action>
     </actions>
-    <text>HDF5: PVI</text>
+    <text>HDF5</text>
     <x>278</x>
     <y>55</y>
     <width>125</width>
@@ -75,7 +75,7 @@
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label</name>
-    <text>SEQ: PVI</text>
+    <text>SEQ</text>
     <x>23</x>
     <y>80</y>
     <width>250</width>
@@ -90,7 +90,7 @@
         <description>Open Display</description>
       </action>
     </actions>
-    <text>SEQ: PVI</text>
+    <text>SEQ</text>
     <x>278</x>
     <y>80</y>
     <width>125</width>
@@ -99,7 +99,7 @@
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label</name>
-    <text>PULSE: PVI</text>
+    <text>PULSE</text>
     <x>23</x>
     <y>105</y>
     <width>250</width>
@@ -114,7 +114,7 @@
         <description>Open Display</description>
       </action>
     </actions>
-    <text>PULSE: PVI</text>
+    <text>PULSE</text>
     <x>278</x>
     <y>105</y>
     <width>125</width>

--- a/tests/test_ioc_system.py
+++ b/tests/test_ioc_system.py
@@ -385,10 +385,11 @@ async def test_create_bobfiles_deletes_existing_files_with_clear_bobfiles(
     non_bobfile.touch()
 
     Pvi.configure_pvi(tmp_path, True)
+    pv = new_random_test_prefix + ":PCAP:TRIG_EDGE"
     Pvi.add_pvi_info(
-        new_random_test_prefix + ":PCAP:TRIG_EDGE",
+        pv,
         PviGroup.PARAMETERS,
-        SignalX("TRIG_EDGE", "Falling"),
+        SignalX(name="TrigEdge", pv=pv, value="Falling"),
     )
     Pvi.create_pvi_records(new_random_test_prefix)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,10 @@
+import pytest
+
 from pandablocks_ioc._types import (
     EpicsName,
     PandAName,
     epics_to_panda_name,
+    epics_to_pvi_name,
     panda_to_epics_name,
     trim_description,
     trim_string_value,
@@ -21,6 +24,21 @@ def test_panda_to_epics_and_back_name_conversion() -> None:
     assert epics_to_panda_name(
         panda_to_epics_name(PandAName("ABC.123.456"))
     ) == PandAName("ABC.123.456")
+
+
+@pytest.mark.parametrize(
+    "arg_result",
+    [
+        ("WOW:WHAT:A_THINGY", "AThingy"),
+        ("WOW:WHAT:A-THINGY", "AThingy"),
+        ("WOW:WHAT:aTHINGY", "Athingy"),
+        ("WOW:WHAT:A_THINGY123", "AThingy123"),
+        ("WOW:WHAT:A-THINGY_123", "AThingy123"),
+    ],
+)
+def test_epics_to_pvi_name(arg_result):
+    arg, result = arg_result
+    assert epics_to_pvi_name(arg) == result
 
 
 def test_string_value():


### PR DESCRIPTION
PVI [now uses](https://github.com/epics-containers/pvi/releases/tag/0.7) `Components` and `Widgets` which are pydantic models. The names we use in the PandA have to be adjusted to fit the schema.

Additionally I pinned PVI to 0.7.* in the pyproject.toml.