### PR TITLE
Support for ':' (colon) characters in PV prefix

### DIFF
--- a/src/pandablocks_ioc/ioc.py
+++ b/src/pandablocks_ioc/ioc.py
@@ -362,7 +362,9 @@ class _RecordUpdater:
             )
             try:
                 if self.record_info.record:
-                    record_name = self.record_info.record.name.removeprefix(self.record_prefix)
+                    record_name = self.record_info.record.name.removeprefix(
+                        self.record_prefix + ":"
+                    )
 
                     assert record_name in self.all_values_dict
                     old_val = self.all_values_dict[record_name]

--- a/src/pandablocks_ioc/ioc.py
+++ b/src/pandablocks_ioc/ioc.py
@@ -309,6 +309,7 @@ class _RecordUpdater:
 
     Args:
         record_info: The RecordInfo structure for the record
+        record_prefix: The prefix of the record name
         client: The client used to send data to PandA
         all_values_dict: The dictionary containing the most recent value of all records
             as returned from GetChanges. This dict will be dynamically updated by other

--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -88,11 +88,11 @@ def mocked_time_record_updater(
         yield (
             _TimeRecordUpdater(
                 mocked_record_info,
+                new_random_test_prefix,
                 client,
                 {},
                 ["TEST1", "TEST2", "TEST3"],
                 base_record,
-                new_random_test_prefix,
                 True,
             ),
             new_random_test_prefix,

--- a/tests/test_ioc.py
+++ b/tests/test_ioc.py
@@ -51,10 +51,11 @@ def record_updater() -> _RecordUpdater:
     client.send = AsyncMock()  # type: ignore
     record_info = RecordInfo(float)
     mocked_record = MagicMock()
-    mocked_record.name = "PREFIX:ABC:DEF"
+    record_prefix = "PREFIX:ES"
+    mocked_record.name = record_prefix + ":ABC:DEF"
     record_info.add_record(mocked_record)
 
-    return _RecordUpdater(record_info, client, {}, None)
+    return _RecordUpdater(record_info, record_prefix, client, {}, None)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds support for PV prefixes with contain `':'` (colon) characters, such as `PANDA:ES`. The existing code failed to properly handle such PVs, since the `_RecordUpdater` class was separating PV name into prefix and record name by splitting the PV name using `':'` as a separator. Changes proposed in this PR, replace splitting-based method by explicit removal of the known prefix from the PV name. The `record_prefix` is added as an attribute of the `_RecordUpdater` class.

The changes are not expected to modify the behavior of the IOC. Unit tests are modified to reflect changes in the code.