### PR TITLE
Add two records: CreateDirectories and DirectoryExists. Automatically create directories based on this PV like in AD

### DIFF
--- a/docs/how-to/capture-hdf.md
+++ b/docs/how-to/capture-hdf.md
@@ -9,7 +9,7 @@ These can be viewed from the DATA screen.
 ```
 
 - The file directory and name are chosen with `:DATA:HDFDirectory` and `:DATA:HDFFileName`.
-- The number of directories that the IOC is allowed to create provided they don't exist is determined by `:DATA:CreateDirectory`. The behavior of this signal is the same the identical PV in [`areaDetector`](https://areadetector.github.io/areaDetector/ADCore/NDPluginFile.html).
+- The number of directories that the IOC is allowed to create provided they don't exist is determined by `:DATA:CreateDirectory`. The behavior of this signal is the same as the identical PV in [`areaDetector`](https://areadetector.github.io/areaDetector/ADCore/NDPluginFile.html).
 - `DATA:DirectoryExists` represents whether or not the directory specified exists and is writable by the user under which the IOC is running.
 - `:DATA:NumCapture` is the number of frames to capture in the file.
 - `:DATA:NumCaptured` is the number of frames written to file.

--- a/docs/how-to/capture-hdf.md
+++ b/docs/how-to/capture-hdf.md
@@ -9,6 +9,8 @@ These can be viewed from the DATA screen.
 ```
 
 - The file directory and name are chosen with `:DATA:HDFDirectory` and `:DATA:HDFFileName`.
+- The number of directories that the IOC is allowed to create provided they don't exist is determined by `:DATA:CreateDirectory`. The behavior of this signal is the same the identical PV in [`areaDetector`](https://areadetector.github.io/areaDetector/ADCore/NDPluginFile.html).
+- `DATA:DirectoryExists` represents whether or not the directory specified exists and is writable by the user under which the IOC is running.
 - `:DATA:NumCapture` is the number of frames to capture in the file.
 - `:DATA:NumCaptured` is the number of frames written to file.
 - `:DATA:NumReceived` is the number of frames received from the panda.

--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -550,7 +550,7 @@ class HDF5RecordController:
         return True
 
     async def _update_directory_path(self, new_val) -> None:
-        """Handles writest to the directory path PV, creating
+        """Handles writes to the directory path PV, creating
         directories based on the setting of the CreateDirectory record"""
         new_path = Path(new_val).absolute()
         create_dir_depth = self._create_directory_record.get()

--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -620,8 +620,7 @@ class HDF5RecordController:
         sevr = alarm.NO_ALARM
         alrm = alarm.NO_ALARM
         if self._directory_exists_record.get() == 0:
-            sevr = alarm.MAJOR_ALARM
-            alrm = alarm.STATE_ALARM
+            sevr = alarm.MAJOR_ALARM, alrm = alarm.STATE_ALARM
             logging.error(status_msg)
         else:
             logging.debug(status_msg)

--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -591,9 +591,6 @@ class HDF5RecordController:
 
         logging.debug(f"Need to create {dirs_to_create} directories.")
 
-        # Default message is "OK"
-        status_msg = "OK"
-
         # Case where all dirs exist
         if dirs_to_create == 0:
             if os.access(new_path, os.W_OK):
@@ -617,12 +614,11 @@ class HDF5RecordController:
             status_msg = f"Need to create {dirs_to_create} > {max_dirs_to_create} dirs."
             self._directory_exists_record.set(0)
 
-        sevr = alarm.NO_ALARM
-        alrm = alarm.NO_ALARM
         if self._directory_exists_record.get() == 0:
             sevr = alarm.MAJOR_ALARM, alrm = alarm.STATE_ALARM
             logging.error(status_msg)
         else:
+            sevr = alarm.NO_ALARM, alrm = alarm.NO_ALARM
             logging.debug(status_msg)
 
         self._status_message_record.set(status_msg, severity=sevr, alarm=alrm)

--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -362,6 +362,12 @@ class HDF5RecordController:
             initial_value=0,
             DESC="Directory creation depth",
         )
+        add_automatic_pvi_info(
+            PviGroup.HDF,
+            self._create_directory_record,
+            create_directory_record_name,
+            builder.longOut,
+        )
         self._create_directory_record.add_alias(
             record_prefix + ":" + create_directory_record_name.upper()
         )
@@ -373,6 +379,12 @@ class HDF5RecordController:
             ONAM="Yes",
             initial_value=0,
             DESC="Directory exists",
+        )
+        add_automatic_pvi_info(
+            PviGroup.HDF,
+            self._directory_exists_record,
+            directory_exists_name,
+            builder.boolIn,
         )
         self._directory_exists_record.add_alias(
             record_prefix + ":" + directory_exists_name.upper()
@@ -585,13 +597,14 @@ class HDF5RecordController:
         # Case where all dirs exist
         if dirs_to_create == 0:
             if os.access(new_path, os.W_OK):
+                status_msg = "Dir exists and is writable"
                 self._directory_exists_record.set(1)
             else:
                 status_msg = "Dirs exist but aren't writable."
                 self._directory_exists_record.set(0)
         # Case where we will create directories
         elif dirs_to_create <= max_dirs_to_create:
-            logging.info(f"Attempting to create {dirs_to_create} dir(s)...")
+            logging.debug(f"Attempting to create {dirs_to_create} dir(s)...")
             try:
                 os.makedirs(new_path, exist_ok=True)
                 status_msg = f"Created {dirs_to_create} dirs."
@@ -611,7 +624,7 @@ class HDF5RecordController:
             alrm = alarm.STATE_ALARM
             logging.error(status_msg)
         else:
-            logging.debug("Directory exists or has been successfully created.")
+            logging.debug(status_msg)
 
         self._status_message_record.set(status_msg, severity=sevr, alarm=alrm)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,23 @@
 # flake8: noqa
 
+import os
+
 from fixtures.mocked_panda import *
 from fixtures.panda_data import *
+
+
+# Autouse fixture that will set all EPICS networking env vars to use lo interface
+# to avoid false failures caused by things like firewalls blocking EPICS traffic.
+@pytest.fixture(scope="session", autouse=True)
+def configure_epics_environment():
+    os.environ["EPICS_CAS_INTF_ADDR_LIST"] = "127.0.0.1"
+    os.environ["EPICS_CAS_BEACON_ADDR_LIST"] = "127.0.0.1"
+    os.environ["EPICS_CA_ADDR_LIST"] = "127.0.0.1"
+    os.environ["EPICS_CAS_AUTO_ADDR_LIST"] = "NO"
+    os.environ["EPICS_CA_AUTO_BEACON_ADDR_LIST"] = "NO"
+
+    os.environ["EPICS_PVAS_INTF_ADDR_LIST"] = "127.0.0.1"
+    os.environ["EPICS_PVAS_BEACON_ADDR_LIST"] = "127.0.0.1"
+    os.environ["EPICS_PVA_ADDR_LIST"] = "127.0.0.1"
+    os.environ["EPICS_PVAS_AUTO_BEACON_ADDR_LIST"] = "NO"
+    os.environ["EPICS_PVA_AUTO_ADDR_LIST"] = "NO"

--- a/tests/test-bobfiles/DATA.bob
+++ b/tests/test-bobfiles/DATA.bob
@@ -3,7 +3,7 @@
   <x>0</x>
   <y>0</y>
   <width>506</width>
-  <height>413</height>
+  <height>463</height>
   <grid_step_x>4</grid_step_x>
   <grid_step_y>4</grid_step_y>
   <widget type="label" version="2.0.0">
@@ -30,7 +30,7 @@
     <x>5</x>
     <y>30</y>
     <width>496</width>
-    <height>106</height>
+    <height>156</height>
     <transparent>true</transparent>
     <widget type="label" version="2.0.0">
       <name>Label</name>
@@ -52,7 +52,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>Hdf File Name</text>
+      <text>Createdirectory</text>
       <x>0</x>
       <y>25</y>
       <width>250</width>
@@ -60,9 +60,47 @@
     </widget>
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
-      <pv_name>TEST_PREFIX:DATA:HDF_FILE_NAME</pv_name>
+      <pv_name>TEST_PREFIX:DATA:CreateDirectory</pv_name>
       <x>255</x>
       <y>25</y>
+      <width>205</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Directoryexists</text>
+      <x>0</x>
+      <y>50</y>
+      <width>250</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>TEST_PREFIX:DATA:DirectoryExists</pv_name>
+      <x>255</x>
+      <y>50</y>
+      <width>205</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Hdf File Name</text>
+      <x>0</x>
+      <y>75</y>
+      <width>250</width>
+      <height>20</height>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>TEST_PREFIX:DATA:HDF_FILE_NAME</pv_name>
+      <x>255</x>
+      <y>75</y>
       <width>205</width>
       <height>20</height>
       <horizontal_alignment>1</horizontal_alignment>
@@ -72,7 +110,7 @@
       <name>Label</name>
       <text>Hdf Full File Path</text>
       <x>0</x>
-      <y>50</y>
+      <y>100</y>
       <width>250</width>
       <height>20</height>
     </widget>
@@ -80,7 +118,7 @@
       <name>TextUpdate</name>
       <pv_name>TEST_PREFIX:DATA:HDF_FULL_FILE_PATH</pv_name>
       <x>255</x>
-      <y>50</y>
+      <y>100</y>
       <width>205</width>
       <height>20</height>
       <font>
@@ -94,7 +132,7 @@
   <widget type="group" version="2.0.0">
     <name>CAPTURE</name>
     <x>5</x>
-    <y>141</y>
+    <y>191</y>
     <width>496</width>
     <height>206</height>
     <transparent>true</transparent>
@@ -268,7 +306,7 @@
   <widget type="group" version="2.0.0">
     <name>OUTPUTS</name>
     <x>5</x>
-    <y>352</y>
+    <y>402</y>
     <width>496</width>
     <height>56</height>
     <transparent>true</transparent>

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -406,6 +406,7 @@ async def test_hdf5_ioc_parameter_validate_works(
         (0, ".", False, True),
         (1, "panda_test5", False, True),
         (-1, "panda_test6", False, True),
+        (10, "panda_test7", False, False),
     ],
 )
 async def test_hdf5_dir_creation(
@@ -616,9 +617,9 @@ async def test_hdf5_file_writing_last_n_endreason_not_ok(
     )
     assert await caget(hdf5_test_prefix + ":NumCapture") == num_capture
 
-    # Initially Status should be "OK"
+    # Initially Status should be "Dir exists and is writable"
     val = await caget(hdf5_test_prefix + ":Status", datatype=DBR_CHAR_STR)
-    assert val == "OK"
+    assert val == "Dir exists and is writable"
 
     await caput(hdf5_test_prefix + ":Capture", 1, wait=True, timeout=TIMEOUT)
 

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -619,7 +619,7 @@ async def test_hdf5_file_writing_last_n_endreason_not_ok(
 
     # Initially Status should be "Dir exists and is writable"
     val = await caget(hdf5_test_prefix + ":Status", datatype=DBR_CHAR_STR)
-    assert val == "Dir exists and is writable"
+    assert val == "OK"
 
     await caput(hdf5_test_prefix + ":Capture", 1, wait=True, timeout=TIMEOUT)
 

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -431,9 +431,7 @@ async def test_hdf5_directory_creation(
         wait=True,
     )
     exists = await caget(hdf5_test_prefix + ":DirectoryExists")
-    status = await caget(hdf5_test_prefix + ":Status", datatype=DBR_CHAR_STR)
 
-    print(f"Path: {str(path)}, IOC status: {status}, exists: {exists}")
     assert (exists > 0) == expect_exists
     if expect_exists:
         assert os.path.exists(target_path)
@@ -560,7 +558,6 @@ async def test_hdf5_file_writing_last_n_endreason_not_ok(
     assert val == test_filename
 
     val = await caget(hdf5_test_prefix + ":HDFFullFilePath", datatype=DBR_CHAR_STR)
-    print(val)
     assert val == "/".join([str(tmp_path), test_filename])
 
     # Only a single FrameData in the example data

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -400,11 +400,8 @@ async def test_hdf5_ioc_parameter_validate_works(
         (1, "panda_test4/depth_2", True),
         (0, "/", False),
         (-1, "/panda_test5", False),
-        (
-            0,
-            ".",
-            True,
-        ),  # make sure our final test passes, so final status message is "OK"
+        # make sure our final test passes, so final status message is "OK"
+        (0, ".", True),
     ],
 )
 async def test_hdf5_directory_creation(


### PR DESCRIPTION
Marking as draft until I can write tests and perform a full test with a real PandA system, but this works in my initial testing.

Designed to work just like the AD `CreateDirectory` system: https://github.com/areaDetector/ADCore/blob/631fb284dc06d52b9286e62418a80f7f3a7a05e2/docs/ADCore/NDPluginFile.rst?plain=1#L57-L64

The `DirectoryExists` record is also meant to behave the same as in areaDetector, and prevent attempting to write the HDF file if the target does not exist or is not writable by the user running the IOC process.