### PR TITLE
pinned the new release of pytest-asyncio: 0.21.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dev = [
     "pre-commit",
     "p4p",
     "pydata-sphinx-theme>=0.12",
-    "pytest-asyncio==0.21.1",    # https://github.com/PandABlocks/PandABlocks-ioc/issues/84
+    "pytest>=8.2.0",
+    "pytest-asyncio~=0.21.2",    # https://github.com/PandABlocks/PandABlocks-ioc/issues/84
     "pytest-cov",
     "ruff",
     "sphinx-autobuild",


### PR DESCRIPTION
As documented in https://github.com/pytest-dev/pytest/issues/12269,

The newer release of pytest broke `pytest-asyncio==0.21.1`. There's now a new patch release of `pytest-asyncio` for those still using `0.21`.