### PR TITLE
Edit dir creation records to standard to fix PVI output

### DIFF
--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -428,7 +428,7 @@ class HDF5RecordController:
             record_prefix + ":" + self.DATA_PREFIX + ":HDFDirectory"
         )
 
-        create_directory_record_name = EpicsName(self.DATA_PREFIX + ":CreateDirectory")
+        create_directory_record_name = EpicsName(self.DATA_PREFIX + ":CREATE_DIRECTORY")
         self._create_directory_record = builder.longOut(
             create_directory_record_name,
             initial_value=0,
@@ -441,10 +441,10 @@ class HDF5RecordController:
             builder.longOut,
         )
         self._create_directory_record.add_alias(
-            record_prefix + ":" + create_directory_record_name.upper()
+            record_prefix + ":" + self.DATA_PREFIX + ":CreateDirectory"
         )
 
-        directory_exists_name = EpicsName(self.DATA_PREFIX + ":DirectoryExists")
+        directory_exists_name = EpicsName(self.DATA_PREFIX + ":DIRECTORY_EXISTS")
         self._directory_exists_record = builder.boolIn(
             directory_exists_name,
             ZNAM="No",
@@ -459,7 +459,7 @@ class HDF5RecordController:
             builder.boolIn,
         )
         self._directory_exists_record.add_alias(
-            record_prefix + ":" + directory_exists_name.upper()
+            record_prefix + ":" + self.DATA_PREFIX + ":DirectoryExists"
         )
 
         file_name_record_name = EpicsName(self.DATA_PREFIX + ":HDF_FILE_NAME")

--- a/tests/test-bobfiles/DATA.bob
+++ b/tests/test-bobfiles/DATA.bob
@@ -52,7 +52,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>Createdirectory</text>
+      <text>Create Directory</text>
       <x>0</x>
       <y>25</y>
       <width>250</width>
@@ -60,7 +60,7 @@
     </widget>
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
-      <pv_name>TEST_PREFIX:DATA:CreateDirectory</pv_name>
+      <pv_name>TEST_PREFIX:DATA:CREATE_DIRECTORY</pv_name>
       <x>255</x>
       <y>25</y>
       <width>205</width>
@@ -69,7 +69,7 @@
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
-      <text>Directoryexists</text>
+      <text>Directory Exists</text>
       <x>0</x>
       <y>50</y>
       <width>250</width>
@@ -77,7 +77,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
-      <pv_name>TEST_PREFIX:DATA:DirectoryExists</pv_name>
+      <pv_name>TEST_PREFIX:DATA:DIRECTORY_EXISTS</pv_name>
       <x>255</x>
       <y>50</y>
       <width>205</width>


### PR DESCRIPTION
When testing https://github.com/bluesky/ophyd-async/pull/503 against a real PandA, I found that the PVI names for the records were not as expected. After converting to follow the other ones it works. Note the missing `_` character in the structure name, and the different format of the PV name:

```
XF:31ID1-ES{PANDA:1}:DATA:PVI structure                                         
    structure record                                                            
        structure _options                                                      
            boolean atomic true                                                 
    structure pvi                                                               
        structure capture                                                       
            string rw XF:31ID1-ES{PANDA:1}:DATA:CAPTURE                         
        structure capture_mode                                                  
            string rw XF:31ID1-ES{PANDA:1}:DATA:CAPTURE_MODE                    
        structure createdirectory                                               
            string rw XF:31ID1-ES{PANDA:1}:DATA:CreateDirectory                 
        structure datasets                                                      
            string r XF:31ID1-ES{PANDA:1}:DATA:DATASETS                         
        structure directoryexists                                               
            string r XF:31ID1-ES{PANDA:1}:DATA:DirectoryExists                             
```

vs

```
XF:31ID1-ES{PANDA:1}:DATA:PVI structure                          
    structure record                                             
        structure _options                                       
            boolean atomic true                                  
    structure pvi                                                
        structure capture                                        
            string rw XF:31ID1-ES{PANDA:1}:DATA:CAPTURE          
        structure capture_mode                                   
            string rw XF:31ID1-ES{PANDA:1}:DATA:CAPTURE_MODE     
        structure create_directory                               
            string rw XF:31ID1-ES{PANDA:1}:DATA:CREATE_DIRECTORY 
        structure datasets                                       
            string r XF:31ID1-ES{PANDA:1}:DATA:DATASETS          
        structure directory_exists                               
            string r XF:31ID1-ES{PANDA:1}:DATA:DIRECTORY_EXISTS  

```