### PR TITLE
134 phoebus screen for positions makes integers

### DIFF
--- a/src/pandablocks_ioc/_pvi.py
+++ b/src/pandablocks_ioc/_pvi.py
@@ -206,7 +206,7 @@ def add_positions_table_row(
         SignalRW(
             name=epics_to_pvi_name(units_record_name),
             label=units_record_name,
-            write_pv=f"{Pvi.record_prefix}:{value_record_name}",
+            write_pv=f"{Pvi.record_prefix}:{units_record_name}",
             write_widget=TextWrite(),
         ),
         SignalRW(

--- a/src/pandablocks_ioc/ioc.py
+++ b/src/pandablocks_ioc/ioc.py
@@ -923,6 +923,7 @@ class IocRecordFactory:
             INPB=builder.CP(record_dict[scale_record_name].record),
             INPC=builder.CP(record_dict[offset_record_name].record),
             DESC="Value with scaling applied",
+            PREC=5,
         )
 
         # Create the POSITIONS "table" of records. Most are aliases of the records


### PR DESCRIPTION
Closes #134 

Made the pos out calc fields (which are aliased as `:VAL`) have precision 5. Also corrected the units column in the positions table to be the correct PVs.