### PR TITLE
stopped vectorising fields

### DIFF
--- a/src/pandablocks_ioc/_pvi.py
+++ b/src/pandablocks_ioc/_pvi.py
@@ -47,6 +47,7 @@ def q_group_formatter(
     access: str,
     channel: Literal["VAL", "NAME"],
     other_fields: dict[str, str] | None = None,
+    vectorize: bool = True,
 ) -> dict:
     other_fields = other_fields or {}
 
@@ -56,9 +57,14 @@ def q_group_formatter(
     pvi_field = f"pvi.{panda_field_lower}.{access}"
 
     # New `value.someblock[1]` field.
-    stripped_name, stripped_number = _extract_number_at_end_of_string(panda_field_lower)
-    value_number = "" if stripped_number is None else f"[{stripped_number}]"
-    value_field = f"value.{stripped_name}{value_number}.{access}"
+    if vectorize:
+        stripped_name, stripped_number = _extract_number_at_end_of_string(
+            panda_field_lower
+        )
+        value_number = "" if stripped_number is None else f"[{stripped_number}]"
+        value_field = f"value.{stripped_name}{value_number}.{access}"
+    else:
+        value_field = f"value.{panda_field_lower}.{access}"
 
     return {
         block_name_suffixed: {
@@ -102,15 +108,10 @@ def add_pvi_info_to_record(
 ):
     block, field = record_name.split(":", maxsplit=1)
     pvi_pv = RecordName(f"{block}:PVI")
+
     record.add_info(
         "Q:group",
-        {
-            pvi_pv: q_group_formatter(
-                field,
-                access,
-                "NAME",
-            )
-        },
+        {pvi_pv: q_group_formatter(field, access, "NAME", vectorize=False)},
     )
 
 


### PR DESCRIPTION
The diff in `pvget -v PANDA1:SFP2_SYNC_IN:PVI`:

``` diff
9,11c9,11
<     time_t timeStamp 2024-11-01 15:08:17.784  
<         long secondsPastEpoch 1730473697
<         int nanoseconds 784397578
---
>     time_t timeStamp 2024-11-01 15:10:16.744  
>         long secondsPastEpoch 1730473816
>         int nanoseconds 744414767
91,108c91,106
<         structure[] bit
<             (none)
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:BIT1
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:BIT2
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:BIT3
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:BIT4
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:BIT5
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:BIT6
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:BIT7
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:BIT8
---
>         structure bit1
>             string r PANDA1:SFP2_SYNC_IN:BIT1
>         structure bit2
>             string r PANDA1:SFP2_SYNC_IN:BIT2
>         structure bit3
>             string r PANDA1:SFP2_SYNC_IN:BIT3
>         structure bit4
>             string r PANDA1:SFP2_SYNC_IN:BIT4
>         structure bit5
>             string r PANDA1:SFP2_SYNC_IN:BIT5
>         structure bit6
>             string r PANDA1:SFP2_SYNC_IN:BIT6
>         structure bit7
>             string r PANDA1:SFP2_SYNC_IN:BIT7
>         structure bit8
>             string r PANDA1:SFP2_SYNC_IN:BIT8
116a115,116
>         structure pos1
>             string r PANDA1:SFP2_SYNC_IN:POS1
126a127,128
>         structure pos2
>             string r PANDA1:SFP2_SYNC_IN:POS2
136a139,140
>         structure pos3
>             string r PANDA1:SFP2_SYNC_IN:POS3
146a151,152
>         structure pos4
>             string r PANDA1:SFP2_SYNC_IN:POS4
157,166d162
<         structure[] pos
<             (none)
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:POS1
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:POS2
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:POS3
<             structure 
<                 string r PANDA1:SFP2_SYNC_IN:POS4
```

No difference in `PANDA1:PVI`.