### PR TITLE
Adding records for tracking version of IOC and PandA firmware

### DIFF
--- a/src/pandablocks_ioc/_pvi.py
+++ b/src/pandablocks_ioc/_pvi.py
@@ -89,6 +89,7 @@ class PviGroup(Enum):
     CAPTURE = "Capture"
     HDF = "HDF"
     TABLE = "Table"  # TODO: May not need this anymore
+    VERSIONS = "Versions"
 
 
 @dataclass

--- a/src/pandablocks_ioc/ioc.py
+++ b/src/pandablocks_ioc/ioc.py
@@ -1865,7 +1865,7 @@ class IocRecordFactory:
 
         return record_dict
 
-    def create_version_records(self, fw_vers_dict: dict[str, str]):
+    def create_version_records(self, fw_vers_dict: dict[EpicsName, str]):
         """Creates handful of records for tracking versions of IOC/Firmware via EPICS
 
         Args:

--- a/src/pandablocks_ioc/ioc.py
+++ b/src/pandablocks_ioc/ioc.py
@@ -200,12 +200,7 @@ async def get_panda_versions(
     else:
         for firmware_name in firmware_versions:
             pattern = re.compile(
-                rf'{re.escape(firmware_name)}:\s*([^:]+?)(?=\s*\b(?:{"|".join(
-                        map(
-                            re.escape,
-                            firmware_versions
-                        )
-                    )}):|$)'
+                rf'{re.escape(firmware_name)}:\s*([^:]+?)(?=\s*\b(?:{"|".join(map(re.escape, firmware_versions))}):|$)'  # noqa: E501
             )
             if match := pattern.search(idn):
                 firmware_versions[firmware_name] = match.group(1).strip()

--- a/tests/fixtures/mocked_panda.py
+++ b/tests/fixtures/mocked_panda.py
@@ -22,6 +22,7 @@ from pandablocks.commands import (
     ChangeGroup,
     Command,
     Disarm,
+    Get,
     GetBlockInfo,
     GetChanges,
     GetFieldInfo,
@@ -430,6 +431,10 @@ def multiple_seq_responses(table_field_info, table_data_1, table_data_2):
     GetChanges is polled at 10Hz if a different command isn't made.
     """
     return {
+        command_to_key(Get(field="*IDN")): repeat(
+            "PandA SW: 3.0-11-g6422090 FPGA: 3.0.0C4 86e5f0a2 07d202f8 \
+             rootfs: PandA 3.1a1-1-g22fdd94"
+        ),
         command_to_key(
             Put(
                 field="SEQ1.TABLE",
@@ -564,6 +569,10 @@ def no_numbered_suffix_to_metadata_responses(table_field_info, table_data_1):
     doesn't have a suffixed number.
     """
     return {
+        command_to_key(Get(field="*IDN")): repeat(
+            "PandA SW: 3.0-11-g6422090 FPGA: 3.0.0C4 86e5f0a2 07d202f8 \
+             rootfs: PandA 3.1a1-1-g22fdd94"
+        ),
         command_to_key(
             Put(
                 field="SEQ.TABLE",
@@ -639,6 +648,10 @@ def faulty_multiple_pcap_responses():
         ),
     }
     return {
+        command_to_key(Get(field="*IDN")): repeat(
+            "PandA SW: 3.0-11-g6422090 FPGA: 3.0.0C4 86e5f0a2 07d202f8 \
+             rootfs: PandA 3.1a1-1-g22fdd94"
+        ),
         command_to_key(GetFieldInfo(block="PCAP1", extended_metadata=True)): repeat(
             pcap_info
         ),
@@ -681,6 +694,10 @@ def standard_responses_no_panda_update(table_field_info, table_data_1):
     Used to test if the softioc can be started.
     """
     return {
+        command_to_key(Get(field="*IDN")): repeat(
+            "PandA SW: 3.0-11-g6422090 FPGA: 3.0.0C4 86e5f0a2 07d202f8 \
+             rootfs: PandA 3.1a1-1-g22fdd94"
+        ),
         command_to_key(GetFieldInfo(block="PCAP", extended_metadata=True)): repeat(
             {
                 "TRIG_EDGE": EnumFieldInfo(
@@ -737,6 +754,10 @@ def standard_responses(table_field_info, table_data_1, table_data_2):
     GetChanges is polled at 10Hz if a different command isn't made.
     """
     return {
+        command_to_key(Get(field="*IDN")): repeat(
+            "PandA SW: 3.0-11-g6422090 FPGA: 3.0.0C4 86e5f0a2 07d202f8 \
+             rootfs: PandA 3.1a1-1-g22fdd94"
+        ),
         command_to_key(GetFieldInfo(block="PCAP", extended_metadata=True)): repeat(
             {
                 "TRIG_EDGE": EnumFieldInfo(

--- a/tests/test-bobfiles/SYSTEM.bob
+++ b/tests/test-bobfiles/SYSTEM.bob
@@ -1,0 +1,128 @@
+<display version="2.0.0">
+  <name>SYSTEM</name>
+  <x>0</x>
+  <y use_class="true">0</y>
+  <width>506</width>
+  <height>166</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>SYSTEM</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>506</width>
+    <height>25</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>VERSIONS</name>
+    <x>5</x>
+    <y>30</y>
+    <width>496</width>
+    <height>131</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Ioc Version</text>
+      <x>0</x>
+      <y>0</y>
+      <width>250</width>
+      <height>20</height>
+      <tooltip>$(text)</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>TEST_PREFIX:SYSTEM:IOC_VERSION</pv_name>
+      <x>255</x>
+      <y>0</y>
+      <width>205</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+      <format>6</format>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Panda Sw Version</text>
+      <x>0</x>
+      <y>25</y>
+      <width>250</width>
+      <height>20</height>
+      <tooltip>$(text)</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>TEST_PREFIX:SYSTEM:PANDA_SW_VERSION</pv_name>
+      <x>255</x>
+      <y>25</y>
+      <width>205</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+      <format>6</format>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Fpga Version</text>
+      <x>0</x>
+      <y>50</y>
+      <width>250</width>
+      <height>20</height>
+      <tooltip>$(text)</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>TEST_PREFIX:SYSTEM:FPGA_VERSION</pv_name>
+      <x>255</x>
+      <y>50</y>
+      <width>205</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+      <format>6</format>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Rootfs Version</text>
+      <x>0</x>
+      <y>75</y>
+      <width>250</width>
+      <height>20</height>
+      <tooltip>$(text)</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>TEST_PREFIX:SYSTEM:ROOTFS_VERSION</pv_name>
+      <x>255</x>
+      <y>75</y>
+      <width>205</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+      <format>6</format>
+    </widget>
+  </widget>
+</display>

--- a/tests/test-bobfiles/index.bob
+++ b/tests/test-bobfiles/index.bob
@@ -3,7 +3,7 @@
   <x>0</x>
   <y use_class="true">0</y>
   <width>488</width>
-  <height>130</height>
+  <height>155</height>
   <grid_step_x>4</grid_step_x>
   <grid_step_y>4</grid_step_y>
   <widget type="label" version="2.0.0">
@@ -27,9 +27,34 @@
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label</name>
-    <text>PCAP</text>
+    <text>SYSTEM</text>
     <x>23</x>
     <y>30</y>
+    <width>250</width>
+    <height>20</height>
+    <tooltip>$(text)</tooltip>
+  </widget>
+  <widget type="action_button" version="3.0.0">
+    <name>OpenDisplay</name>
+    <actions>
+      <action type="open_display">
+        <file>SYSTEM.bob</file>
+        <target>tab</target>
+        <description>Open Display</description>
+      </action>
+    </actions>
+    <text>SubScreen</text>
+    <x>278</x>
+    <y>30</y>
+    <width>205</width>
+    <height>20</height>
+    <tooltip>$(actions)</tooltip>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>PCAP</text>
+    <x>23</x>
+    <y>55</y>
     <width>250</width>
     <height>20</height>
     <tooltip>$(text)</tooltip>
@@ -45,7 +70,7 @@
     </actions>
     <text>SubScreen</text>
     <x>278</x>
-    <y>30</y>
+    <y>55</y>
     <width>205</width>
     <height>20</height>
     <tooltip>$(actions)</tooltip>
@@ -54,7 +79,7 @@
     <name>Label</name>
     <text>DATA</text>
     <x>23</x>
-    <y>55</y>
+    <y>80</y>
     <width>250</width>
     <height>20</height>
     <tooltip>$(text)</tooltip>
@@ -70,7 +95,7 @@
     </actions>
     <text>SubScreen</text>
     <x>278</x>
-    <y>55</y>
+    <y>80</y>
     <width>205</width>
     <height>20</height>
     <tooltip>$(actions)</tooltip>
@@ -79,7 +104,7 @@
     <name>Label</name>
     <text>SEQ</text>
     <x>23</x>
-    <y>80</y>
+    <y>105</y>
     <width>250</width>
     <height>20</height>
     <tooltip>$(text)</tooltip>
@@ -95,7 +120,7 @@
     </actions>
     <text>SubScreen</text>
     <x>278</x>
-    <y>80</y>
+    <y>105</y>
     <width>205</width>
     <height>20</height>
     <tooltip>$(actions)</tooltip>
@@ -104,7 +129,7 @@
     <name>Label</name>
     <text>PULSE</text>
     <x>23</x>
-    <y>105</y>
+    <y>130</y>
     <width>250</width>
     <height>20</height>
     <tooltip>$(text)</tooltip>
@@ -120,7 +145,7 @@
     </actions>
     <text>SubScreen</text>
     <x>278</x>
-    <y>105</y>
+    <y>130</y>
     <width>205</width>
     <height>20</height>
     <tooltip>$(actions)</tooltip>

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -13,6 +13,7 @@ from pandablocks.commands import (
     Arm,
     ChangeGroup,
     Disarm,
+    Get,
     GetBlockInfo,
     GetChanges,
     GetFieldInfo,
@@ -47,6 +48,10 @@ async def test_no_panda_found_connection_error():
 def panda_disconnect_responses(table_field_info, table_data_1, table_data_2):
     # The responses return nothing, as the panda disconnects after introspection
     return {
+        command_to_key(Get(field="*IDN")): repeat(
+            "PandA SW: 3.0-11-g6422090 FPGA: 3.0.0C4 86e5f0a2 07d202f8 \
+             rootfs: PandA 3.1a1-1-g22fdd94"
+        ),
         command_to_key(GetFieldInfo(block="PCAP", extended_metadata=True)): repeat(
             {
                 "TRIG_EDGE": EnumFieldInfo(


### PR DESCRIPTION
Would be useful for checking the versions of everything on the floor without needing to get into the IOC console or logging into the IOC server.

```
(venv) [jwlodek@xf31id1-ws3 PandABlocks-ioc]$ caget TEST:PANDA_SW_VERSION 
TEST:PANDA_SW_VERSION          3.0-11-g6422090

(venv) [jwlodek@xf31id1-ws3 PandABlocks-ioc]$ caget TEST:FPGA_VERSION
TEST:FPGA_VERSION              3.0.0C4 86e5f0a2 07d202f8 

(venv) [jwlodek@xf31id1-ws3 PandABlocks-ioc]$ caget TEST:ROOTFS_VERSION
TEST:ROOTFS_VERSION            PandA 3.1a1-1-g22fdd94

(venv) [jwlodek@xf31id1-ws3 PandABlocks-ioc]$ caget TEST:VERSION
TEST:VERSION                   0.11.4.dev0+g1e1e8cd.d20241113
```