### PR TITLE
Use correct table col name

### DIFF
--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -333,7 +333,7 @@ class DatasetNameCache:
             datasets_record_name, ["Name", "Type"]
         )
         self._datasets_table_record.set_rows(
-            ["Name", "HDF5_Type"], [[], []], length=300, default_data_type=str
+            ["Name", "DType"], [[], []], length=300, default_data_type=str
         )
 
     def hdf_writer_names(self) -> dict[str, dict[str, str]]:
@@ -363,7 +363,7 @@ class DatasetNameCache:
         ]
         self._datasets_table_record.update_row("Name", dataset_name_list)
         self._datasets_table_record.update_row(
-            "HDF5_Type",
+            "DType",
             ["float64"] * len(dataset_name_list),
         )
 

--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -333,7 +333,7 @@ class DatasetNameCache:
             datasets_record_name, ["Name", "Type"]
         )
         self._datasets_table_record.set_rows(
-            ["Name", "Type"], [[], []], length=300, default_data_type=str
+            ["Name", "HDF5_Type"], [[], []], length=300, default_data_type=str
         )
 
     def hdf_writer_names(self) -> dict[str, dict[str, str]]:
@@ -363,7 +363,7 @@ class DatasetNameCache:
         ]
         self._datasets_table_record.update_row("Name", dataset_name_list)
         self._datasets_table_record.update_row(
-            "Type",
+            "HDF5_Type",
             ["float64"] * len(dataset_name_list),
         )
 

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -1331,7 +1331,7 @@ def test_dataset_name_cache():
 
         # Check that set_rows was called once with the correct arguments
         mock_table_instance.set_rows.assert_called_once_with(
-            ["Name", "Type"], [[], []], length=300, default_data_type=str
+            ["Name", "HDF5_Type"], [[], []], length=300, default_data_type=str
         )
         cache.update_datasets_record()
 
@@ -1340,7 +1340,7 @@ def test_dataset_name_cache():
             "Name", ["test3", "test4", "test5"]
         )
         mock_table_instance.update_row.assert_any_call(
-            "Type", ["float64", "float64", "float64"]
+            "HDF5_Type", ["float64", "float64", "float64"]
         )
 
         assert cache.hdf_writer_names() == {

--- a/tests/test_hdf_ioc.py
+++ b/tests/test_hdf_ioc.py
@@ -1331,7 +1331,7 @@ def test_dataset_name_cache():
 
         # Check that set_rows was called once with the correct arguments
         mock_table_instance.set_rows.assert_called_once_with(
-            ["Name", "HDF5_Type"], [[], []], length=300, default_data_type=str
+            ["Name", "DType"], [[], []], length=300, default_data_type=str
         )
         cache.update_datasets_record()
 
@@ -1340,7 +1340,7 @@ def test_dataset_name_cache():
             "Name", ["test3", "test4", "test5"]
         )
         mock_table_instance.update_row.assert_any_call(
-            "HDF5_Type", ["float64", "float64", "float64"]
+            "DType", ["float64", "float64", "float64"]
         )
 
         assert cache.hdf_writer_names() == {


### PR DESCRIPTION
Resolves https://github.com/bluesky/ophyd-async/issues/639

Before this change:
```
In [10]: await panda1.data.datasets.get_value()
An exception has occurred, use '%tb verbose' to see the full traceback.
ValidationError: 1 validation error for DatasetTable
type
  Extra inputs are not permitted [type=extra_forbidden, input_value=['float64'], input_type=list]
    For further information visit https://errors.pydantic.dev/2.9/v/extra_forbidden

See /home/xf31id/.cache/bluesky/log/bluesky.log for the full traceback.
```

After this change:
```
In [11]: await test_panda.data.datasets.get_value()
Out[11]: DatasetTable(name=[], hdf5_type=[])

In [12]: await test_panda.data.datasets.get_value()
Out[12]: DatasetTable(name=['TrigTS'], hdf5_type=[<PandaHdf5DatasetType.FLOAT_64: 'float64'>])
```
note the second column title is just `HDF5_Type`, instead of just `Type`.