### PR TITLE
Dynamically add custom pipelines to HDF5 writing flow

### DIFF
--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -153,7 +153,7 @@ class HDF5Buffer:
         number_received_setter: Callable,
         number_captured_setter_pipeline: NumCapturedSetter,
         dataset_name_cache: dict[str, dict[str, str]],
-        custom_pipeline_classes: list[Pipeline],
+        custom_pipeline_classes: Optional[list[Pipeline]] = None,
     ):
         # Only one filename - user must stop capture and set new FileName/FilePath
         # for new files
@@ -178,7 +178,7 @@ class HDF5Buffer:
         self.number_captured_setter_pipeline = number_captured_setter_pipeline
         self.number_captured_setter_pipeline.number_captured_setter(0)
 
-        self.custom_pipeline_classes = custom_pipeline_classes
+        self.custom_pipeline_classes = custom_pipeline_classes or []
 
         self.dataset_name_cache = dataset_name_cache
 

--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -91,6 +91,52 @@ def create_custom_pipeline(
     )
 
 
+def collect_custom_pipeline_classes():
+    """
+    Checks environment variable PANDABLOCKS_IOC_CUSTOM_PIPELINES for the list
+    of custom pipeline modules to add to the HDF5 writer. The pipeline modules
+    should be in the format 'module_name.PipelineClassName', multiple modules
+    should be separated by ':' or '|'.
+
+    Returns a list of custom pipeline instances. The list is empty if there are
+    no custom pipleines specified or if there was an error importing them.
+    """
+    custom_pipeline_classes = []
+    custom_pipelines_str = os.getenv("PANDABLOCKS_IOC_CUSTOM_PIPELINES", None)
+    if custom_pipelines_str:
+        custom_pipelines_str_list = custom_pipelines_str.split(":|")
+        for p in custom_pipelines_str_list:
+            components = p.rsplit(".")
+            if len(components) == 2:
+                module_name, pipeline_name = components
+                try:
+                    mod = importlib.import_module(module_name)
+                    pipeline_class = getattr(mod, pipeline_name)
+
+                    # Run 'env_initialize()' static method (if available)
+                    env_initialize = getattr(pipeline_class, "env_initialize", None)
+                    if env_initialize:
+                        env_initialize()
+
+                    custom_pipeline_classes.append(pipeline_class)
+                    logging.info(
+                        f"Adding custom pipeline {pipeline_name} from {module_name}"
+                    )
+                except Exception as e:
+                    logging.exception(
+                        f"Failed to import custom pipeline {pipeline_name} "
+                        f"from module {module_name}: {e}"
+                    )
+            else:
+                logging.error(
+                    f"Incorrect formatting of custom pipeline module name {p}"
+                )
+
+    if custom_pipeline_classes:
+        logging.info(f"The number of custom pipelines: {len(custom_pipeline_classes)}")
+    return custom_pipeline_classes
+
+
 class HDF5Buffer:
     _buffer_index = None
     start_data = None
@@ -107,6 +153,7 @@ class HDF5Buffer:
         number_received_setter: Callable,
         number_captured_setter_pipeline: NumCapturedSetter,
         dataset_name_cache: dict[str, dict[str, str]],
+        custom_pipeline_classes: list[Pipeline],
     ):
         # Only one filename - user must stop capture and set new FileName/FilePath
         # for new files
@@ -131,6 +178,8 @@ class HDF5Buffer:
         self.number_captured_setter_pipeline = number_captured_setter_pipeline
         self.number_captured_setter_pipeline.number_captured_setter(0)
 
+        self.custom_pipeline_classes = custom_pipeline_classes
+
         self.dataset_name_cache = dataset_name_cache
 
         if (
@@ -151,7 +200,7 @@ class HDF5Buffer:
         except Exception as ex:
             logging.exception(f"Failed to save the data to HDF5 file: {ex}")
 
-    def _add_custom_pipelines(self, dataset_name_cache):
+    def _add_custom_pipelines(self, file_names, dataset_name_cache):
         """
         Checks environment variable PANDABLOCKS_IOC_CUSTOM_PIPELINES for the list
         of custom pipeline modules to add to the HDF5 writer. The pipeline modules
@@ -162,31 +211,15 @@ class HDF5Buffer:
         no custom pipleines specified or if there was an error importing them.
         """
         custom_pipelines = []
-        custom_pipelines_str = os.getenv("PANDABLOCKS_IOC_CUSTOM_PIPELINES", None)
-        if custom_pipelines_str:
-            custom_pipelines_str_list = custom_pipelines_str.split(":|")  
-            for p in custom_pipelines_str_list:
-                components = p.rsplit(".")
-                if len(components) == 2:
-                    module_name, pipeline_name = components
-                    try:
-                        mod = importlib.import_module(module_name)
-                        pipeline_class = getattr(mod, pipeline_name)
-                        pipeline = pipeline_class(dataset_name_cache)  # Instantiate the pipeline class
-                        custom_pipelines.append(pipeline)
-                        logging.info(f"Adding custom pipeline {pipeline_name} from {module_name}")
-                    except Exception as e:
-                        logging.exception(
-                            f"Failed to import custom pipeline {pipeline_name} "
-                            f"from module {module_name}: {e}"
-                        )
-                else:
-                    logging.error(f"Incorrect formatting of custom pipeline module name {p}")
-
+        for pipeline_class in self.custom_pipeline_classes:
+            pipeline = pipeline_class(file_names, dataset_name_cache)
+            custom_pipelines.append(pipeline)
         return custom_pipelines
 
     def start_pipeline(self):
-        custom_pipelines = self._add_custom_pipelines(self.dataset_name_cache)
+        custom_pipelines = self._add_custom_pipelines(
+            iter([self.filepath]), self.dataset_name_cache
+        )
         self.pipeline = create_custom_pipeline(
             iter([self.filepath]),
             custom_pipelines,
@@ -689,6 +722,8 @@ class HDF5RecordController:
             record_prefix + ":" + self.DATA_PREFIX + ":Status"
         )
 
+        self.custom_pipeline_classes = collect_custom_pipeline_classes()
+
     def _parameter_validate(self, record: RecordWrapper, new_val) -> bool:
         """Control when values can be written to parameter records
         (file name etc.) based on capturing record's value"""
@@ -801,6 +836,7 @@ class HDF5RecordController:
                 self._num_received_record.set,
                 number_captured_setter_pipeline,
                 self._datasets.hdf_writer_names(),
+                self.custom_pipeline_classes,
             )
             flush_period: float = self._flush_period_record.get()
             async for data in self._client.data(

--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -3,9 +3,10 @@ import logging
 import os
 from asyncio import CancelledError
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from enum import Enum
+import importlib
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Optional, Union
@@ -16,8 +17,11 @@ from pandablocks.hdf import (
     FrameData,
     Pipeline,
     StartData,
-    create_default_pipeline,
+    # create_default_pipeline,
+    create_pipeline,
     stop_pipeline,
+    FrameProcessor,
+    HDFWriter,
 )
 from pandablocks.responses import EndReason, ReadyData
 from softioc import alarm, builder
@@ -56,6 +60,35 @@ class NumCapturedSetter(Pipeline):
 
     def set_record(self, value: int):
         self.number_captured_setter(value)
+
+
+def create_custom_pipeline(
+    file_names: Iterator[str],
+    custom_pipelines: Iterator[Pipeline],
+    capture_record_hdf_names: dict[str, dict[str, str]],
+    *additional_downstream_pipelines: Pipeline,
+) -> list[Pipeline]:
+    """Create the processing pipeline consisting of one `FrameProcessor`,
+    and `HDFWriter`. Custom pipelines (from external packages) are called before
+    `HDFWriter`. See `create_pipeline` for more details.
+
+    Args:
+        file_names: Iterator of file names. Must be full file paths. Will be called once
+            per file created. As required by `HDFWriter`.
+        custom_pipelines: Iterator of user-provided pipelines.
+        capture_record_hdf_names: A dictionary of dataset names to use for each field.
+            The keys are record names, the values are another dictionary of
+            capture type to dataset name.
+        additional_downstream_pipelines: Any number of additional pipelines to add
+            downstream.
+    """
+
+    return create_pipeline(
+        FrameProcessor(),
+        *custom_pipelines,
+        HDFWriter(file_names, capture_record_hdf_names),
+        *additional_downstream_pipelines,
+    )
 
 
 class HDF5Buffer:
@@ -118,9 +151,45 @@ class HDF5Buffer:
         except Exception as ex:
             logging.exception(f"Failed to save the data to HDF5 file: {ex}")
 
+    def _add_custom_pipelines(self, dataset_name_cache):
+        """
+        Checks environment variable PANDABLOCKS_IOC_CUSTOM_PIPELINES for the list
+        of custom pipeline modules to add to the HDF5 writer. The pipeline modules
+        should be in the format 'module_name.PipelineClassName', multiple modules
+        should be separated by ':' or '|'.
+
+        Returns a list of custom pipeline instances. The list is empty if there are
+        no custom pipleines specified or if there was an error importing them.
+        """
+        custom_pipelines = []
+        custom_pipelines_str = os.getenv("PANDABLOCKS_IOC_CUSTOM_PIPELINES", None)
+        if custom_pipelines_str:
+            custom_pipelines_str_list = custom_pipelines_str.split(":|")  
+            for p in custom_pipelines_str_list:
+                components = p.rsplit(".")
+                if len(components) == 2:
+                    module_name, pipeline_name = components
+                    try:
+                        mod = importlib.import_module(module_name)
+                        pipeline_class = getattr(mod, pipeline_name)
+                        pipeline = pipeline_class(dataset_name_cache)  # Instantiate the pipeline class
+                        custom_pipelines.append(pipeline)
+                        logging.info(f"Adding custom pipeline {pipeline_name} from {module_name}")
+                    except Exception as e:
+                        logging.exception(
+                            f"Failed to import custom pipeline {pipeline_name} "
+                            f"from module {module_name}: {e}"
+                        )
+                else:
+                    logging.error(f"Incorrect formatting of custom pipeline module name {p}")
+
+        return custom_pipelines
+
     def start_pipeline(self):
-        self.pipeline = create_default_pipeline(
+        custom_pipelines = self._add_custom_pipelines(self.dataset_name_cache)
+        self.pipeline = create_custom_pipeline(
             iter([self.filepath]),
+            custom_pipelines,
             self.dataset_name_cache,
             self.number_captured_setter_pipeline,
         )

--- a/src/pandablocks_ioc/_hdf_ioc.py
+++ b/src/pandablocks_ioc/_hdf_ioc.py
@@ -62,7 +62,7 @@ class NumCapturedSetter(Pipeline):
         self.number_captured_setter(value)
 
 
-def create_custom_pipeline(
+def create_ioc_pipeline(
     file_names: Iterator[str],
     custom_pipelines: Iterator[Pipeline],
     capture_record_hdf_names: dict[str, dict[str, str]],
@@ -220,7 +220,7 @@ class HDF5Buffer:
         custom_pipelines = self._add_custom_pipelines(
             iter([self.filepath]), self.dataset_name_cache
         )
-        self.pipeline = create_custom_pipeline(
+        self.pipeline = create_ioc_pipeline(
             iter([self.filepath]),
             custom_pipelines,
             self.dataset_name_cache,


### PR DESCRIPTION
The feature allows to dynamically add custom pipelines to the HDF5 writing flow. The code for the custom pipeline(s) must be contained in one of the installed modules. The name of the module(s) and the pipeline class(es) are specified in the `PANDABLOCKS_IOC_CUSTOM_PIPELINES` environment variable. If the module name or the list of modules is discovered, the IOC loads the pipeline classes from the modules and inserts them in the HDF5 writing pipeline after the FrameProcessor and before HDFWriter. The developer of the custom pipeline is responsible to make sure the pipeline is does not block the flow or change the data.

The example of custom pipeline that performs real-time streaming of collected data over 0MQ may be found here: https://github.com/NSLS2/PandABlocks-ioc-zmq-stream . The pipeline can be added to the IOC by setting

```
PANDABLOCKS_IOC_CUSTOM_PIPELINES=pandablocks_ioc_zmq_stream.ZMQPublisher
```

Changes to the IOC code: 

- A new function `collect_custom_pipeline_classes` that returns the list of custom pipeline classes;
- A new function `create_ioc_pipeline` replaces the function `create_default_pipeline` (from `pandablocks` module);
- A new parameter `custom_pipeline_classes` (a list of custom pipeline classes) are added to `HDF5Buffer` class constructor.

The behavior of the IOC is not expected to change if there are no custom pipelines.